### PR TITLE
Proper CppReference attribution

### DIFF
--- a/content/docs/std/containers/arrays/array.mdx
+++ b/content/docs/std/containers/arrays/array.mdx
@@ -5,7 +5,11 @@ sidebar_label:		array
 description:		Summary of a std::array (usage, methods, etc.) - C++ Language
 tags:				[array, container, bounds, compile-time]
 hide_title:			true
+
+cppreference_origin_rel: w/cpp/container/array
 ---
+
+<!--- Components ---->
 
 import ClassSummary				from "@site-comps/ClassSummary";
 import CustomCodeBlock			from "@site-comps/CustomCodeBlock";
@@ -13,10 +17,14 @@ import SymbolTable, { Symbol }	from "@site-comps/SymbolTable";
 import Columns					from "@site-comps/Columns";
 import SwitchView				from "@site-comps/SwitchView";
 import Image					from "@site-comps/Image";
-import NotFinished				from "@site/i18n/en/presets/NotFinished.mdx";
-import ImproveSection			from "@site/i18n/en/presets/ImproveSection.mdx";
+
 import Tabs						from "@theme/Tabs";
 import TabItem					from "@theme/TabItem";
+
+<!--- Presets ---->
+
+import NotFinished				from "@site/i18n/en/presets/NotFinished.mdx";
+import ImproveSection			from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!------------------ Codes ----------------->
 

--- a/content/docs/std/containers/arrays/array/at.mdx
+++ b/content/docs/std/containers/arrays/array/at.mdx
@@ -4,6 +4,8 @@ sidebar_label:			at( )
 description:			array<...>::at() method C++ documentation
 hide_title:				true
 tags:					[access, array, index, bounds]
+
+cppreference_origin_rel: w/cpp/container/array/at
 ---
 
 # std::array at() method

--- a/content/docs/std/containers/arrays/array/back.mdx
+++ b/content/docs/std/containers/arrays/array/back.mdx
@@ -4,11 +4,13 @@ sidebar_label:			back( )
 description:			array<...>::back() method C++ documentation
 hide_title:				true
 tags:					[access, array, last, back]
+
+cppreference_origin_rel: w/cpp/container/array/back
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip					from "@site-comps/Tooltip";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
 
 <!-- Terms -->
 import Term_ContAlias_Reference	from "@site/i18n/en/presets/terms/cont-alias-reference.mdx";
@@ -17,18 +19,18 @@ import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behav
 <!----------------- Codes ---------------------->
 
 <!-- back() -->
-import Method_UntilCpp14 	from './_codes/back/until-cpp14.mdx';
-import Method_SinceCpp14 	from './_codes/back/since-cpp14.mdx';
-import Method_SinceCpp17 	from './_codes/back/since-cpp17.mdx';
+import Method_UntilCpp14	from './_codes/back/until-cpp14.mdx';
+import Method_SinceCpp14	from './_codes/back/since-cpp14.mdx';
+import Method_SinceCpp17	from './_codes/back/since-cpp17.mdx';
 
 
 # std::array back() method
 
 <SwitchView content={{
-        'since-cpp17': <Method_SinceCpp17 />,
-        'since-cpp14': <Method_SinceCpp14 />,
-        'until-cpp14': <Method_UntilCpp14 />,
-    }}/>
+	'since-cpp17': <Method_SinceCpp17 />,
+	'since-cpp14': <Method_SinceCpp14 />,
+	'until-cpp14': <Method_UntilCpp14 />,
+}}/>
 
 Returns a <Tooltip title={Term_ContAlias_Reference}>reference</Tooltip> to the last element in the container.
 Calling back on an empty container is <Tooltip title={Term_UndefinedBehaviour}>undefined</Tooltip>.

--- a/content/docs/std/containers/arrays/array/begin.mdx
+++ b/content/docs/std/containers/arrays/array/begin.mdx
@@ -4,13 +4,15 @@ sidebar_label:			begin( )
 description:			array<...>::begin() method C++ documentation
 hide_title:				true
 tags:					[access, array, iterator, begin, front]
+
+cppreference_origin_rel: w/cpp/container/array/begin
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import TabItem					from "@theme/TabItem";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
+import TabItem				from "@theme/TabItem";
 
 <!-- Terms -->
 import Term_ContAlias_Iterator from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";
@@ -18,15 +20,15 @@ import Term_ContAlias_Iterator from "@site/i18n/en/presets/terms/cont-alias-iter
 <!----------------- Codes ---------------------->
 
 <!-- begin() -->
-import Method_UntilCpp17 	from './_codes/begin/until-cpp17.mdx';
-import Method_SinceCpp17 	from './_codes/begin/since-cpp17.mdx';
+import Method_UntilCpp17	from './_codes/begin/until-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/begin/since-cpp17.mdx';
 
 # std::array begin()/cbegin() method
 
 <SwitchView content={{
-		'since-cpp17': <Method_SinceCpp17 />,
-		'until-cpp17': <Method_UntilCpp17 />,
-	}}/>
+	'since-cpp17': <Method_SinceCpp17 />,
+	'until-cpp17': <Method_UntilCpp17 />,
+}}/>
 
 Returns an <Tooltip title={Term_ContAlias_Iterator}>iterator</Tooltip> to the first element of the array.
 If the array is empty, the returned iterator will be equal to `end()`.

--- a/content/docs/std/containers/arrays/array/data.mdx
+++ b/content/docs/std/containers/arrays/array/data.mdx
@@ -4,23 +4,25 @@ sidebar_label:			data( )
 description:			array<...>::data() method C++ documentation
 hide_title:				true
 tags:					[access, array, pointer, data, raw]
+
+cppreference_origin_rel: w/cpp/container/array/data
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- data() -->
-import Method_UntilCpp17 	from './_codes/data/until-cpp17.mdx';
-import Method_SinceCpp17 	from './_codes/data/since-cpp17.mdx';
+import Method_UntilCpp17	from './_codes/data/until-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/data/since-cpp17.mdx';
 
 # std::array data() method
 
 <SwitchView content={{
-        'since-cpp17': <Method_SinceCpp17 />,
-        'until-cpp17': <Method_UntilCpp17 />,
-    }}/>
+	'since-cpp17': <Method_SinceCpp17 />,
+	'until-cpp17': <Method_UntilCpp17 />,
+}}/>
 
 Returns pointer to the underlying array serving as element storage.
 The pointer is such that range **[ `data()`; `data() + size()` )** is always a valid range,

--- a/content/docs/std/containers/arrays/array/empty.mdx
+++ b/content/docs/std/containers/arrays/array/empty.mdx
@@ -4,23 +4,25 @@ sidebar_label:			empty( )
 description:			array<...>::empty() method C++ documentation
 hide_title:				true
 tags:					[array, empty]
+
+cppreference_origin_rel: w/cpp/container/array/empty
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- empty() -->
-import Method_UntilCpp20 	from './_codes/empty/until-cpp20.mdx';
-import Method_SinceCpp20 	from './_codes/empty/since-cpp20.mdx';
+import Method_UntilCpp20	from './_codes/empty/until-cpp20.mdx';
+import Method_SinceCpp20	from './_codes/empty/since-cpp20.mdx';
 
 # std::array empty() method
 
 <SwitchView content={{
-        'since-cpp20': <Method_SinceCpp20 />,
-        'until-cpp20': <Method_UntilCpp20 />,
-    }}/>
+	'since-cpp20': <Method_SinceCpp20 />,
+	'until-cpp20': <Method_UntilCpp20 />,
+}}/>
 
 
 Checks if the container has no elements, i.e. whether `begin() == end()`.

--- a/content/docs/std/containers/arrays/array/end.mdx
+++ b/content/docs/std/containers/arrays/array/end.mdx
@@ -4,26 +4,28 @@ sidebar_label:			end( )
 description:			array<...>::end() method C++ documentation
 hide_title:				true
 tags:					[access, array, iterator, end, back]
+
+cppreference_origin_rel: w/cpp/container/array/end
 ---
 
 import Columns					from "@site-comps/Columns";
 import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
+import Tooltip					from "@site-comps/Tooltip";
 
-import ImproveSection           from "@site/i18n/en/presets/ImproveSection.mdx"
+import ImproveSection			from "@site/i18n/en/presets/ImproveSection.mdx"
 
-import Tabs				        from "@theme/Tabs";
+import Tabs						from "@theme/Tabs";
 import TabItem					from "@theme/TabItem";
 
 <!-- Terms -->
-import Term_ContAlias_Iterator from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";
-import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
+import Term_ContAlias_Iterator	from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";
+import Term_UndefinedBehaviour	from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- end() -->
-import Method_UntilCpp17 	from './_codes/end/until-cpp17.mdx';
-import Method_SinceCpp17 	from './_codes/end/since-cpp17.mdx';
+import Method_UntilCpp17		from './_codes/end/until-cpp17.mdx';
+import Method_SinceCpp17		from './_codes/end/since-cpp17.mdx';
 
 
 # std::array end()/cend() method

--- a/content/docs/std/containers/arrays/array/fill.mdx
+++ b/content/docs/std/containers/arrays/array/fill.mdx
@@ -4,15 +4,18 @@ sidebar_label:			fill( )
 description:			array<...>::fill() method C++ documentation
 hide_title:				true
 tags:					[access, array, index, bounds]
+
+cppreference_origin_rel: w/cpp/container/array/fill
 ---
+
 import Columns				from "@site-comps/Columns";
 import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- fill() -->
-import Method_UntilCpp20 	from './_codes/fill/until-cpp20.mdx';
-import Method_SinceCpp20 	from './_codes/fill/since-cpp20.mdx';
+import Method_UntilCpp20	from './_codes/fill/until-cpp20.mdx';
+import Method_SinceCpp20	from './_codes/fill/since-cpp20.mdx';
 
 # std::array fill() method
 

--- a/content/docs/std/containers/arrays/array/front.mdx
+++ b/content/docs/std/containers/arrays/array/front.mdx
@@ -4,6 +4,8 @@ sidebar_label:			front( )
 description:			array<...>::front() method C++ documentation
 hide_title:				true
 tags:					[access, array, first, front]
+
+cppreference_origin_rel: w/cpp/container/array/front
 ---
 
 import Columns					from "@site-comps/Columns";
@@ -12,23 +14,23 @@ import Tooltip					from "@site-comps/Tooltip";
 
 <!-- Terms -->
 import Term_ContAlias_Reference	from "@site/i18n/en/presets/terms/cont-alias-reference.mdx";
-import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
+import Term_UndefinedBehaviour	from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- front() -->
-import Method_UntilCpp14 	from './_codes/front//until-cpp14.mdx';
-import Method_SinceCpp14 	from './_codes/front/since-cpp14.mdx';
-import Method_SinceCpp17 	from './_codes/front/since-cpp17.mdx';
+import Method_UntilCpp14		from './_codes/front//until-cpp14.mdx';
+import Method_SinceCpp14		from './_codes/front/since-cpp14.mdx';
+import Method_SinceCpp17		from './_codes/front/since-cpp17.mdx';
 
 
 # std::array front() method
 
 <SwitchView content={{
-		'since-cpp17': <Method_SinceCpp17 />,
-		'since-cpp14': <Method_SinceCpp14 />,
-		'until-cpp14': <Method_UntilCpp14 />,
-	}}/>
+	'since-cpp17': <Method_SinceCpp17 />,
+	'since-cpp14': <Method_SinceCpp14 />,
+	'until-cpp14': <Method_UntilCpp14 />,
+}}/>
 
 Returns a <Tooltip title={Term_ContAlias_Reference}>reference</Tooltip> to the first element in the container.
 Calling front on an empty container is <Tooltip title={Term_UndefinedBehaviour}>undefined</Tooltip>.

--- a/content/docs/std/containers/arrays/array/max_size.mdx
+++ b/content/docs/std/containers/arrays/array/max_size.mdx
@@ -4,21 +4,23 @@ sidebar_label:			max_size( )
 description:			array<...>::max_size() method C++ documentation
 hide_title:				true
 tags:					[array, max, maximum, most, size, elements]
+
+cppreference_origin_rel: w/cpp/container/array/max_size
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- max_size() -->
-import Method_SinceCpp11 	from './_codes/max_size/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/max_size/since-cpp11.mdx';
 
 # std::array max_size() method
 
 <SwitchView content={{
-        'since-cpp11': <Method_SinceCpp11 />,
-    }}/>
+	'since-cpp11': <Method_SinceCpp11 />,
+}}/>
 
 		
 Returns the **maximum number of elements** the container is able to hold due to system or library implementation limitations,

--- a/content/docs/std/containers/arrays/array/operator_subscript.mdx
+++ b/content/docs/std/containers/arrays/array/operator_subscript.mdx
@@ -4,6 +4,8 @@ sidebar_label:			operator[]
 description:			array<...>::operator[] C++ documentation
 hide_title:				true
 tags:					[subscript, access, array, index]
+
+cppreference_origin_rel: w/cpp/container/array/operator_at
 ---
 
 # std::array operator[]
@@ -19,9 +21,9 @@ import Term_ContAlias_Reference	from "@site/i18n/en/presets/terms/cont-alias-ref
 
 <!-- operator[] -->
 
-import Method_UntilCpp14 	from './_codes/at/until-cpp14.mdx';
-import Method_SinceCpp14 	from './_codes/at/since-cpp14.mdx';
-import Method_SinceCpp17 	from './_codes/at/since-cpp17.mdx';
+import Method_UntilCpp14		from './_codes/at/until-cpp14.mdx';
+import Method_SinceCpp14		from './_codes/at/since-cpp14.mdx';
+import Method_SinceCpp17		from './_codes/at/since-cpp17.mdx';
 
 <SwitchView content={{
 		'since-cpp17': <Method_SinceCpp17 />,

--- a/content/docs/std/containers/arrays/array/rbegin.mdx
+++ b/content/docs/std/containers/arrays/array/rbegin.mdx
@@ -4,13 +4,15 @@ sidebar_label:			rbegin()
 description:			array<...>::rbegin() method C++ documentation
 hide_title:				true
 tags:					[access, array, reverse, begin]
+
+cppreference_origin_rel: w/cpp/container/array/rbegin
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import TabItem					from "@theme/TabItem";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
+import TabItem				from "@theme/TabItem";
 
 <!-- Terms -->
 import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
@@ -18,8 +20,8 @@ import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-ali
 <!----------------- Codes ---------------------->
 
 <!-- rbegin() -->
-import Method_UntilCpp17 	from './_codes/rbegin/until-cpp17.mdx';
-import Method_SinceCpp17 	from './_codes/rbegin/since-cpp17.mdx';
+import Method_UntilCpp17	from './_codes/rbegin/until-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/rbegin/since-cpp17.mdx';
 
 # std::array rbegin()/crbegin() method
 

--- a/content/docs/std/containers/arrays/array/rend.mdx
+++ b/content/docs/std/containers/arrays/array/rend.mdx
@@ -4,26 +4,28 @@ sidebar_label:			rend()
 description:			array<...>::rend() method C++ documentation
 hide_title:				true
 tags:					[access, array, index, bounds]
+
+cppreference_origin_rel: w/cpp/container/array/rend
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
 
-import ImproveSection           from "@site/i18n/en/presets/ImproveSection.mdx"
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx"
 
-import Tabs				        from "@theme/Tabs";
-import TabItem					from "@theme/TabItem";
+import Tabs					from "@theme/Tabs";
+import TabItem				from "@theme/TabItem";
 
 <!-- Terms -->
-import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
-import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
+import Term_ContAlias_ReverseIterator	from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
+import Term_UndefinedBehaviour			from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- rbegin() -->
-import Method_UntilCpp17 	from './_codes/rend/until-cpp17.mdx';
-import Method_SinceCpp17 	from './_codes/rend/since-cpp17.mdx';
+import Method_UntilCpp17	from './_codes/rend/until-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/rend/since-cpp17.mdx';
 
 # std::array rend()/crend() method
 

--- a/content/docs/std/containers/arrays/array/size.mdx
+++ b/content/docs/std/containers/arrays/array/size.mdx
@@ -4,6 +4,8 @@ sidebar_label:			size( )
 description:			array<...>::size() method C++ documentation
 hide_title:				true
 tags:					[array, size, elements]
+
+cppreference_origin_rel: w/cpp/container/array/size
 ---
 
 import Columns				from "@site-comps/Columns";
@@ -12,13 +14,13 @@ import SwitchView			from "@site-comps/SwitchView";
 <!----------------- Codes ---------------------->
 
 <!-- size() -->
-import Method_SinceCpp11 	from './_codes/size/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/size/since-cpp11.mdx';
 
 # std::array size() method
 
 <SwitchView content={{
-        'since-cpp11': <Method_SinceCpp11 />,
-    }}/>
+	'since-cpp11': <Method_SinceCpp11 />,
+}}/>
 
 Returns the number of elements in the container, i.e. `std::distance(begin(), end())`.
 

--- a/content/docs/std/containers/arrays/array/swap.mdx
+++ b/content/docs/std/containers/arrays/array/swap.mdx
@@ -4,10 +4,12 @@ sidebar_label:			swap( )
 description:			array<...>::swap() method C++ documentation
 hide_title:				true
 tags:					[array, swap]
+
+cppreference_origin_rel: w/cpp/container/array/swap
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 
 <!----------------- Codes ---------------------->
@@ -16,21 +18,21 @@ import SwitchView				from "@site-comps/SwitchView";
 import Method_UntilCpp20 	from './_codes/swap/until-cpp20.mdx';
 import Method_SinceCpp20 	from './_codes/swap/since-cpp20.mdx';
 
-import NoexceptSpecification_UntilCpp17 	from './_codes/swap/noexcept-specification/until-cpp17.mdx';
-import NoexceptSpecification_SinceCpp17 	from './_codes/swap/noexcept-specification/since-cpp17.mdx';
+import NoexceptSpecification_UntilCpp17	from './_codes/swap/noexcept-specification/until-cpp17.mdx';
+import NoexceptSpecification_SinceCpp17	from './_codes/swap/noexcept-specification/since-cpp17.mdx';
 
 # std::array swap() method
 
 <SwitchView content={{
-    'since-cpp20': <Method_SinceCpp20 />,
-    'until-cpp20': <Method_UntilCpp20 />,
+	'since-cpp20': <Method_SinceCpp20 />,
+	'until-cpp20': <Method_UntilCpp20 />,
 }}/>
 
 The noexcept specification for these two looks like follows:
 
 <SwitchView content={{
-    'until-cpp17': <NoexceptSpecification_UntilCpp17 />,
-    'since-cpp17': <NoexceptSpecification_SinceCpp17 />
+	'until-cpp17': <NoexceptSpecification_UntilCpp17 />,
+	'since-cpp17': <NoexceptSpecification_SinceCpp17 />
 }}/>
 
 Exchanges the contents of the container with those of other.

--- a/content/docs/std/containers/arrays/array/to_array.mdx
+++ b/content/docs/std/containers/arrays/array/to_array.mdx
@@ -4,6 +4,8 @@ sidebar_label:			to_array( )
 description:			to_array() function C++ documentation
 hide_title:				true
 tags:					[array, helper, to_array]
+
+cppreference_origin_rel: w/cpp/container/array/to_array
 ---
 
 import Columns				from "@site-comps/Columns";

--- a/content/docs/std/containers/arrays/vector.mdx
+++ b/content/docs/std/containers/arrays/vector.mdx
@@ -5,6 +5,8 @@ sidebar_label:		vector
 description:		Summary of a std::vector (usage, methods, etc.) - C++ Language
 tags:				[vector, container, dynamic, array, allocation, resizable]
 hide_title:			true
+
+cppreference_origin_rel: w/cpp/container/vector
 ---
 
 import ClassSummary				from "@site-comps/ClassSummary";

--- a/content/docs/std/containers/arrays/vector/assign.mdx
+++ b/content/docs/std/containers/arrays/vector/assign.mdx
@@ -4,16 +4,18 @@ sidebar_label:			assign( )
 description:			vector<...>::assign() method C++ documentation
 hide_title:				true
 tags:					[vector, assign, copy]
+
+cppreference_origin_rel: w/cpp/container/vector/assign
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
 
 <!-- Terms -->
-import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
-import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
+import Term_ContAlias_ReverseIterator	from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
+import Term_UndefinedBehaviour			from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/arrays/vector/at.mdx
+++ b/content/docs/std/containers/arrays/vector/at.mdx
@@ -4,6 +4,8 @@ sidebar_label:			at( )
 description:			vector<...>::at() method C++ documentation
 hide_title:				true
 tags:					[access, vector, index, bounds, method]
+
+cppreference_origin_rel: w/cpp/container/vector/at
 ---
 
 # std::vector at() method

--- a/content/docs/std/containers/arrays/vector/back.mdx
+++ b/content/docs/std/containers/arrays/vector/back.mdx
@@ -4,6 +4,8 @@ sidebar_label:			back( )
 description:			vector<...>::back() method C++ documentation
 hide_title:				true
 tags:					[access, vector, last, back]
+
+cppreference_origin_rel: w/cpp/container/vector/back
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/arrays/vector/begin.mdx
+++ b/content/docs/std/containers/arrays/vector/begin.mdx
@@ -4,13 +4,15 @@ sidebar_label:			begin( )
 description:			vector<...>::begin() method C++ documentation
 hide_title:				true
 tags:					[access, vector, iterator, begin, front]
+
+cppreference_origin_rel: w/cpp/container/vector/begin
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import TabItem					from "@theme/TabItem";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
+import TabItem				from "@theme/TabItem";
 
 <!-- Terms -->
 import Term_ContAlias_Iterator from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";

--- a/content/docs/std/containers/arrays/vector/capacity.mdx
+++ b/content/docs/std/containers/arrays/vector/capacity.mdx
@@ -4,6 +4,8 @@ sidebar_label:			capacity( )
 description:			vector<...>::capacity() method C++ documentation
 hide_title:				true
 tags:					[vector, size, capacity]
+
+cppreference_origin_rel: w/cpp/container/vector/capacity
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/arrays/vector/clear.mdx
+++ b/content/docs/std/containers/arrays/vector/clear.mdx
@@ -4,6 +4,8 @@ sidebar_label:			clear( )
 description:			vector<...>::clear() method C++ documentation
 hide_title:				true
 tags:					[vector, clear, empty, erase, remove]
+
+cppreference_origin_rel: w/cpp/container/vector/clear
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/arrays/vector/constructors.mdx
+++ b/content/docs/std/containers/arrays/vector/constructors.mdx
@@ -4,6 +4,8 @@ sidebar_label:			Constructors
 description:			vector<...> constructors C++ documentation
 hide_title:				true
 tags:					[access, vector, index, bounds, method]
+
+cppreference_origin_rel: w/cpp/container/vector/vector
 ---
 
 # std::vector constructors

--- a/content/docs/std/containers/arrays/vector/data.mdx
+++ b/content/docs/std/containers/arrays/vector/data.mdx
@@ -4,23 +4,25 @@ sidebar_label:			data( )
 description:			vector<...>::data() method C++ documentation
 hide_title:				true
 tags:					[access, vector, data, pointer]
+
+cppreference_origin_rel: w/cpp/container/vector/data
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!-- data() -->
-import Method_UntilCpp11 	from './_codes/data/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/data/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/data/since-cpp20.mdx';
+import Method_UntilCpp11	from './_codes/data/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/data/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/data/since-cpp20.mdx';
 
 # std::vector data() method
 
 <SwitchView content={{
-        'since-cpp20': <Method_SinceCpp20 />,
-        'since-cpp11': <Method_SinceCpp11 />,
-        'until-cpp11': <Method_UntilCpp11 />,
-    }}/>
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+	'until-cpp11': <Method_UntilCpp11 />,
+}}/>
 
 Returns pointer to the underlying array serving as element storage.
 The pointer is such that range **[ `data()`; `data() + size()` )** is always a valid range,

--- a/content/docs/std/containers/arrays/vector/destructor.mdx
+++ b/content/docs/std/containers/arrays/vector/destructor.mdx
@@ -1,22 +1,24 @@
 ---
 title:				vector<...> destructor
-sidebar_label:			Destructor
-description:			vector<...> destructor C++ documentation
+sidebar_label:		Destructor
+description:		vector<...> destructor C++ documentation
 hide_title:			true
 tags:				[vector, destruction, destructor]
+
+cppreference_origin_rel: w/cpp/container/vector/~vector
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!-- destructors -->
-import Method_UntilCpp20 	from './_codes/destructors/until-cpp20.mdx';
-import Method_SinceCpp20 	from './_codes/destructors/since-cpp20.mdx';
+import Method_UntilCpp20	from './_codes/destructors/until-cpp20.mdx';
+import Method_SinceCpp20	from './_codes/destructors/since-cpp20.mdx';
 
 # std::vector destructors
 
 <SwitchView content={{
-        'since-cpp20': <Method_SinceCpp20 />,
-        'until-cpp20': <Method_UntilCpp20 />,
+	'since-cpp20': <Method_SinceCpp20 />,
+	'until-cpp20': <Method_UntilCpp20 />,
 }} />
 
 Destructs the vector. The destructors of the elements are called and the used storage is deallocated. 

--- a/content/docs/std/containers/arrays/vector/emplace.mdx
+++ b/content/docs/std/containers/arrays/vector/emplace.mdx
@@ -4,21 +4,23 @@ sidebar_label:			emplace( )
 description:			vector<...>::emplace() method C++ documentation
 hide_title:				true
 tags:					[vector, emplace, add]
+
+cppreference_origin_rel: w/cpp/container/vector/emplace
 ---
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- emplace() -->
-import Method_SinceCpp11 	from './_codes/emplace/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/emplace/since-cpp20.mdx';
+import Method_SinceCpp11	from './_codes/emplace/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/emplace/since-cpp20.mdx';
 
 # std::vector emplace() method
 
 <SwitchView content={{
-    'since-cpp20': <Method_SinceCpp20 />,
-    'since-cpp11': <Method_SinceCpp11 />,
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp11': <Method_SinceCpp11 />,
 }} />
 
 Inserts a new element into the container directly before `pos`.

--- a/content/docs/std/containers/arrays/vector/emplace_back.mdx
+++ b/content/docs/std/containers/arrays/vector/emplace_back.mdx
@@ -4,11 +4,13 @@ sidebar_label:			emplace_back( )
 description:			vector<...>::emplace_back() method C++ documentation
 hide_title:				true
 tags:					[vector, emplace, emplace_back, add]
+
+cppreference_origin_rel: w/cpp/container/vector/emplace_back
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
 
 <!-- Terms -->
 import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
@@ -16,17 +18,17 @@ import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behav
 <!----------------- Codes ---------------------->
 
 <!-- emplace_back() -->
-import Method_SinceCpp11 	from './_codes/emplace_back/since-cpp11.mdx';
-import Method_SinceCpp17 	from './_codes/emplace_back/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/emplace_back/since-cpp20.mdx';
+import Method_SinceCpp11	from './_codes/emplace_back/since-cpp11.mdx';
+import Method_SinceCpp17	from './_codes/emplace_back/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/emplace_back/since-cpp20.mdx';
 
 # std::vector emplace_back() method
 
 <SwitchView content={{
-    'since-cpp20': <Method_SinceCpp20 />,
-    'since-cpp17': <Method_SinceCpp17 />,
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp17': <Method_SinceCpp17 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Appends a new element to the end of the container.
 The element is constructed through `std::allocator_traits<Alloc>::construct()`, which typically uses placement-new to construct the element in-place at the location provided by the container.

--- a/content/docs/std/containers/arrays/vector/empty.mdx
+++ b/content/docs/std/containers/arrays/vector/empty.mdx
@@ -4,25 +4,27 @@ sidebar_label:			empty( )
 description:			vector<...>::empty() method C++ documentation
 hide_title:				true
 tags:					[vector, empty]
+
+cppreference_origin_rel: w/cpp/container/vector/empty
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- empty() -->
-import Method_UntilCpp11 	from './_codes/empty/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/empty/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/empty/since-cpp20.mdx';
+import Method_UntilCpp11	from './_codes/empty/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/empty/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/empty/since-cpp20.mdx';
 
 # std::vector empty() method
 
 <SwitchView content={{
-        'since-cpp20': <Method_SinceCpp20 />,
-        'since-cpp11': <Method_SinceCpp11 />,
-        'until-cpp11': <Method_UntilCpp11 />,
-    }}/>
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+	'until-cpp11': <Method_UntilCpp11 />,
+}}/>
 
 
 Checks if the container has no elements, i.e. whether `begin() == end()`.

--- a/content/docs/std/containers/arrays/vector/end.mdx
+++ b/content/docs/std/containers/arrays/vector/end.mdx
@@ -4,13 +4,15 @@ sidebar_label:			end( )
 description:			vector<...>::end() method C++ documentation
 hide_title:				true
 tags:					[access, vector, iterator, end, back]
+
+cppreference_origin_rel: w/cpp/container/vector/end
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import TabItem					from "@theme/TabItem";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
+import TabItem				from "@theme/TabItem";
 
 <!-- Terms -->
 import Term_ContAlias_Iterator from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";

--- a/content/docs/std/containers/arrays/vector/erase.mdx
+++ b/content/docs/std/containers/arrays/vector/erase.mdx
@@ -4,12 +4,14 @@ sidebar_label:			erase( )
 description:			vector<...>::erase() method C++ documentation
 hide_title:				true
 tags:					[vector, erase, remove, delete]
+
+cppreference_origin_rel: w/cpp/container/vector/erase
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
 
 <!-- Terms -->
 import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";

--- a/content/docs/std/containers/arrays/vector/front.mdx
+++ b/content/docs/std/containers/arrays/vector/front.mdx
@@ -4,11 +4,13 @@ sidebar_label:			front( )
 description:			vector<...>::front() method C++ documentation
 hide_title:				true
 tags:					[access, vector, first, front, method]
+
+cppreference_origin_rel: w/cpp/container/vector/front
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip					from "@site-comps/Tooltip";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
 
 <!-- Terms -->
 import Term_ContAlias_Reference	from "@site/i18n/en/presets/terms/cont-alias-reference.mdx";
@@ -17,8 +19,8 @@ import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behav
 <!----------------- Codes ---------------------->
 
 <!-- front() -->
-import Method_UntilCpp20 	from './_codes/front/until-cpp20.mdx';
-import Method_SinceCpp20 	from './_codes/front/since-cpp20.mdx';
+import Method_UntilCpp20	from './_codes/front/until-cpp20.mdx';
+import Method_SinceCpp20	from './_codes/front/since-cpp20.mdx';
 
 
 # std::vector front() method

--- a/content/docs/std/containers/arrays/vector/get_allocator.mdx
+++ b/content/docs/std/containers/arrays/vector/get_allocator.mdx
@@ -4,24 +4,26 @@ sidebar_label:			get_allocator( )
 description:			vector<...>::get_allocator() method C++ documentation
 hide_title:				true
 tags:					[vector, allocator, internal, underlying, method]
+
+cppreference_origin_rel: w/cpp/container/vector/get_allocator
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- empty() -->
-import Method_UntilCpp11 	from './_codes/get_allocator/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/get_allocator/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/get_allocator/since-cpp20.mdx';
+import Method_UntilCpp11	from './_codes/get_allocator/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/get_allocator/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/get_allocator/since-cpp20.mdx';
 
 # std::vector get_allocator() method
 
 <SwitchView content={{
-        'since-cpp20': <Method_SinceCpp20 />,
-        'since-cpp11': <Method_SinceCpp11 />,
-        'until-cpp11': <Method_UntilCpp11 />,
-    }}/>
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+	'until-cpp11': <Method_UntilCpp11 />,
+}}/>
 
 
 Returns the allocator associated with the container.

--- a/content/docs/std/containers/arrays/vector/insert.mdx
+++ b/content/docs/std/containers/arrays/vector/insert.mdx
@@ -4,12 +4,14 @@ sidebar_label:			insert( )
 description:			vector<...>::insert() method C++ documentation
 hide_title:				true
 tags:					[vector, insert, add]
+
+cppreference_origin_rel: w/cpp/container/vector/insert
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
 
 <!-- Terms -->
 import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";

--- a/content/docs/std/containers/arrays/vector/max_size.mdx
+++ b/content/docs/std/containers/arrays/vector/max_size.mdx
@@ -4,25 +4,27 @@ sidebar_label:			max_size( )
 description:			vector<...>::max_size() method C++ documentation
 hide_title:				true
 tags:					[vector, max, size, method]
+
+cppreference_origin_rel: w/cpp/container/vector/max_size
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- max_size() -->
-import Method_UntilCpp11 	from './_codes/max_size/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/max_size/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/max_size/since-cpp20.mdx';
+import Method_UntilCpp11	from './_codes/max_size/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/max_size/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/max_size/since-cpp20.mdx';
 
 # std::vector max_size() method
 
 <SwitchView content={{
-        'since-cpp20': <Method_SinceCpp20 />,
-        'since-cpp11': <Method_SinceCpp11 />,
-        'until-cpp11': <Method_UntilCpp11 />,
-    }}/>
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+	'until-cpp11': <Method_UntilCpp11 />,
+}}/>
 
 		
 Returns the **maximum number of elements** the container is able to hold due to system or library implementation limitations,

--- a/content/docs/std/containers/arrays/vector/operator_assign.mdx
+++ b/content/docs/std/containers/arrays/vector/operator_assign.mdx
@@ -4,12 +4,14 @@ sidebar_label:			operator=
 description:			vector<...>::operator= method C++ documentation
 hide_title:				true
 tags:					[vector, assign, copy, operator_assign]
+
+cppreference_origin_rel: w/cpp/container/vector/operator=
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
 
 <!-- Terms -->
 import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
@@ -18,10 +20,10 @@ import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behav
 <!----------------- Codes ---------------------->
 
 <!-- operator_assign() -->
-import Method_UntilCpp11 	from './_codes/operator_assign/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/operator_assign/since-cpp11.mdx';
-import Method_SinceCpp17 	from './_codes/operator_assign/since-cpp17.mdx';
-import Method_SinceCpp20 	from './_codes/operator_assign/since-cpp20.mdx';
+import Method_UntilCpp11	from './_codes/operator_assign/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/operator_assign/since-cpp11.mdx';
+import Method_SinceCpp17	from './_codes/operator_assign/since-cpp17.mdx';
+import Method_SinceCpp20	from './_codes/operator_assign/since-cpp20.mdx';
 
 import CopyAssignment_SinceCpp11_Note from './_codes/operator_assign/other/copy-assignment-since-cpp11-note.mdx';
 import SinceCpp17_Exceptions from './_codes/operator_assign/other/since-cpp17-exceptions.mdx';

--- a/content/docs/std/containers/arrays/vector/operator_subscript.mdx
+++ b/content/docs/std/containers/arrays/vector/operator_subscript.mdx
@@ -4,6 +4,8 @@ sidebar_label:			operator[]
 description:			vector<...>::operator[] C++ documentation
 hide_title:				true
 tags:					[subscript, access, vector, index, method]
+
+cppreference_origin_rel: w/cpp/container/vector/operator_at
 ---
 
 # std::vector operator[]
@@ -18,8 +20,8 @@ import Term_ContAlias_Reference	from "@site/i18n/en/presets/terms/cont-alias-ref
 <!----------------- Codes ---------------------->
 
 <!-- at() -->
-import Method_OpSub_UntilCpp20 	from './_codes/operator_subscript/until-cpp20.mdx';
-import Method_OpSub_SinceCpp20 	from './_codes/operator_subscript/since-cpp20.mdx';
+import Method_OpSub_UntilCpp20	from './_codes/operator_subscript/until-cpp20.mdx';
+import Method_OpSub_SinceCpp20	from './_codes/operator_subscript/since-cpp20.mdx';
 
 <SwitchView content={{
 		'since-cpp20': <Method_OpSub_SinceCpp20 />,

--- a/content/docs/std/containers/arrays/vector/pop_back.mdx
+++ b/content/docs/std/containers/arrays/vector/pop_back.mdx
@@ -4,11 +4,13 @@ sidebar_label:			pop_back( )
 description:			vector<...>::pop_back() method C++ documentation
 hide_title:				true
 tags:					[vector, pop_back, pop, back, last, remove, erase]
+
+cppreference_origin_rel: w/cpp/container/vector/pop_back
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
 
 <!-- Terms -->
 import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
@@ -16,14 +18,14 @@ import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behav
 <!----------------- Codes ---------------------->
 
 <!-- pop_back() -->
-import Method_UntilCpp20 	from './_codes/pop_back/until-cpp20.mdx';
-import Method_SinceCpp20 	from './_codes/pop_back/since-cpp20.mdx';
+import Method_UntilCpp20	from './_codes/pop_back/until-cpp20.mdx';
+import Method_SinceCpp20	from './_codes/pop_back/since-cpp20.mdx';
 
 # std::vector pop_back() method
 
 <SwitchView content={{
-    'since-cpp20': <Method_SinceCpp20 />,
-    'until-cpp20': <Method_UntilCpp20 />,
+	'since-cpp20': <Method_SinceCpp20 />,
+	'until-cpp20': <Method_UntilCpp20 />,
 }} />
 
 Removes the last element of the container.

--- a/content/docs/std/containers/arrays/vector/push_back.mdx
+++ b/content/docs/std/containers/arrays/vector/push_back.mdx
@@ -4,12 +4,14 @@ sidebar_label:			push_back( )
 description:			vector<...>::push_back() method C++ documentation
 hide_title:				true
 tags:					[vector, push, add, push_back]
+
+cppreference_origin_rel: w/cpp/container/vector/push_back
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
 
 <!-- Terms -->
 import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
@@ -25,9 +27,9 @@ import Method_SinceCpp20 	from './_codes/push_back/since-cpp20.mdx';
 # std::vector push_back() method
 
 <SwitchView content={{
-    'since-cpp20': <Method_SinceCpp20 />,
-    'since-cpp11': <Method_SinceCpp11 />,
-    'until-cpp11': <Method_UntilCpp11 />,
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+	'until-cpp11': <Method_UntilCpp11 />,
 }} />
 
 Appends the given element value to the end of the container.

--- a/content/docs/std/containers/arrays/vector/rbegin.mdx
+++ b/content/docs/std/containers/arrays/vector/rbegin.mdx
@@ -4,13 +4,15 @@ sidebar_label:			rbegin()
 description:			vector<...>::rbegin() method C++ documentation
 hide_title:				true
 tags:					[access, vector, iterator, reverse, rbegin, begin]
+
+cppreference_origin_rel: w/cpp/container/vector/rbegin
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import TabItem					from "@theme/TabItem";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
+import TabItem				from "@theme/TabItem";
 
 <!-- Terms -->
 import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
@@ -18,17 +20,17 @@ import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-ali
 <!----------------- Codes ---------------------->
 
 <!-- rbegin() -->
-import Method_UntilCpp11 	from './_codes/end/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/end/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/end/since-cpp20.mdx';
+import Method_UntilCpp11	from './_codes/end/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/end/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/end/since-cpp20.mdx';
 
 # std::vector rbegin() method
 
 <SwitchView content={{
-        'since-cpp20': <Method_SinceCpp20 />,
-        'since-cpp11': <Method_SinceCpp11 />,
-        'until-cpp11': <Method_UntilCpp11 />,
-    }}/>
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+	'until-cpp11': <Method_UntilCpp11 />,
+}}/>
 
 Returns a <Tooltip title={Term_ContAlias_ReverseIterator}>reverse iterator</Tooltip> to the first element of the reversed vector.
 It corresponds to the last element of the non-reversed vector.

--- a/content/docs/std/containers/arrays/vector/rend.mdx
+++ b/content/docs/std/containers/arrays/vector/rend.mdx
@@ -4,13 +4,15 @@ sidebar_label:			rend()
 description:			vector<...>::rend() method C++ documentation
 hide_title:				true
 tags:					[access, vector, rend, end]
+
+cppreference_origin_rel: w/cpp/container/vector/rend
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import TabItem					from "@theme/TabItem";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
+import TabItem				from "@theme/TabItem";
 
 <!-- Terms -->
 import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";

--- a/content/docs/std/containers/arrays/vector/reserve.mdx
+++ b/content/docs/std/containers/arrays/vector/reserve.mdx
@@ -4,11 +4,13 @@ sidebar_label:			reserve( )
 description:			vector<...>::reserve() method C++ documentation
 hide_title:				true
 tags:					[vector, reserve, resize]
+
+cppreference_origin_rel: w/cpp/container/vector/reserve
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
 
 <!-- Terms -->
 import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
@@ -16,14 +18,14 @@ import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behav
 <!----------------- Codes ---------------------->
 
 <!-- reserve() -->
-import Method_UntilCpp20 	from './_codes/reserve/until-cpp20.mdx';
-import Method_SinceCpp20 	from './_codes/reserve/since-cpp20.mdx';
+import Method_UntilCpp20	from './_codes/reserve/until-cpp20.mdx';
+import Method_SinceCpp20	from './_codes/reserve/since-cpp20.mdx';
 
 # std::vector reserve() method
 
 <SwitchView content={{
-    'since-cpp20': <Method_SinceCpp20 />,
-    'until-cpp20': <Method_UntilCpp20 />,
+	'since-cpp20': <Method_SinceCpp20 />,
+	'until-cpp20': <Method_UntilCpp20 />,
 }} />
 
 Increase the capacity of the vector (the total number of elements that the vector can hold without requiring reallocation)

--- a/content/docs/std/containers/arrays/vector/resize.mdx
+++ b/content/docs/std/containers/arrays/vector/resize.mdx
@@ -4,12 +4,14 @@ sidebar_label:			resize( )
 description:			vector<...>::resize() method C++ documentation
 hide_title:				true
 tags:					[vector, size, resize, reserve]
+
+cppreference_origin_rel: w/cpp/container/vector/resize
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
 
 <!-- Terms -->
 import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
@@ -18,16 +20,16 @@ import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behav
 <!----------------- Codes ---------------------->
 
 <!-- resize() -->
-import Method_UntilCpp11 	from './_codes/resize/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/resize/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/resize/since-cpp20.mdx';
+import Method_UntilCpp11	from './_codes/resize/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/resize/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/resize/since-cpp20.mdx';
 
 # std::vector resize() method
 
 <SwitchView content={{
-    'since-cpp20': <Method_SinceCpp20 />,
-    'since-cpp11': <Method_SinceCpp11 />,
-    'until-cpp11': <Method_UntilCpp11 />,
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+	'until-cpp11': <Method_UntilCpp11 />,
 }} />
 
 Resizes the container to contain count elements.

--- a/content/docs/std/containers/arrays/vector/shrink_to_fit.mdx
+++ b/content/docs/std/containers/arrays/vector/shrink_to_fit.mdx
@@ -4,11 +4,13 @@ sidebar_label:			shrink_to_fit( )
 description:			vector<...>::shrink_to_fit() method C++ documentation
 hide_title:				true
 tags:					[vector, shrink, clear]
+
+cppreference_origin_rel: w/cpp/container/vector/shrink_to_fit
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
 
 <!-- Terms -->
 import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
@@ -16,14 +18,14 @@ import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behav
 <!----------------- Codes ---------------------->
 
 <!-- shrink_to_fit() -->
-import Method_SinceCpp11 	from './_codes/shrink_to_fit/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/shrink_to_fit/since-cpp20.mdx';
+import Method_SinceCpp11	from './_codes/shrink_to_fit/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/shrink_to_fit/since-cpp20.mdx';
 
 # std::vector shrink_to_fit() method
 
 <SwitchView content={{
-    'since-cpp20': <Method_SinceCpp20 />,
-    'since-cpp11': <Method_SinceCpp11 />,
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp11': <Method_SinceCpp11 />,
 }} />
 
 Requests the removal of unused capacity.

--- a/content/docs/std/containers/arrays/vector/size.mdx
+++ b/content/docs/std/containers/arrays/vector/size.mdx
@@ -4,25 +4,27 @@ sidebar_label:			size( )
 description:			vector<...>::size() method C++ documentation
 hide_title:				true
 tags:					[vector, size]
+
+cppreference_origin_rel: w/cpp/container/vector/size
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- size() -->
-import Method_UntilCpp11 	from './_codes/size/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/size/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/size/since-cpp20.mdx';
+import Method_UntilCpp11	from './_codes/size/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/size/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/size/since-cpp20.mdx';
 
 # std::vector size() method
 
 <SwitchView content={{
-        'since-cpp20': <Method_SinceCpp20 />,
-        'since-cpp11': <Method_SinceCpp11 />,
-        'until-cpp11': <Method_UntilCpp11 />,
-    }}/>
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+	'until-cpp11': <Method_UntilCpp11 />,
+}}/>
 
 
 Returns the number of elements in the container, i.e. `std::distance(begin(), end())`.

--- a/content/docs/std/containers/arrays/vector/std-erase.mdx
+++ b/content/docs/std/containers/arrays/vector/std-erase.mdx
@@ -4,12 +4,14 @@ sidebar_label:			std::erase( ), std::erase_if( )
 description:			std::erase() function C++ documentation
 hide_title:				true
 tags:					[vector, erase, remove, delete]
+
+cppreference_origin_rel: w/cpp/container/vector/erase2
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
 
 <!-- Terms -->
 import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
@@ -18,12 +20,12 @@ import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behav
 <!----------------- Codes ---------------------->
 
 <!-- std-erase() -->
-import Method_SinceCpp20 	from './_codes/std-erase/since-cpp20.mdx';
+import Method_SinceCpp20	from './_codes/std-erase/since-cpp20.mdx';
 
 # std::erase() method
 
 <SwitchView content={{
-    'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp20': <Method_SinceCpp20 />,
 }} />
 
  - **(1)** Erases all elements that compare equal to value from the container. Equivalent to

--- a/content/docs/std/containers/arrays/vector/swap.mdx
+++ b/content/docs/std/containers/arrays/vector/swap.mdx
@@ -4,11 +4,13 @@ sidebar_label:			swap( )
 description:			vector<...>::swap() method C++ documentation
 hide_title:				true
 tags:					[vector, swap, exchange]
+
+cppreference_origin_rel: w/cpp/container/vector/swap
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip					from "@site-comps/Tooltip";
+import Columns		from "@site-comps/Columns";
+import SwitchView	from "@site-comps/SwitchView";
+import Tooltip		from "@site-comps/Tooltip";
 
 <!-- Terms -->
 import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
@@ -16,27 +18,27 @@ import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behav
 <!----------------- Codes ---------------------->
 
 <!-- swap() -->
-import Method_UntilCpp17 	from './_codes/swap/until-cpp17.mdx';
-import Method_SinceCpp17 	from './_codes/swap/since-cpp17.mdx';
-import Method_SinceCpp20 	from './_codes/swap/since-cpp20.mdx';
-import NoexceptSpecification_SinceCpp11 	from './_codes/swap/noexcept-specification/since-cpp11.mdx';
+import Method_UntilCpp17				from './_codes/swap/until-cpp17.mdx';
+import Method_SinceCpp17				from './_codes/swap/since-cpp17.mdx';
+import Method_SinceCpp20				from './_codes/swap/since-cpp20.mdx';
+import NoexceptSpecification_SinceCpp11	from './_codes/swap/noexcept-specification/since-cpp11.mdx';
 
 # std::vector swap() method
 
 
 <SwitchView content={{
-        'since-cpp20': <>
-            <Method_SinceCpp20 />
-            The noexcept specification looks as follows:
-            <NoexceptSpecification_SinceCpp11 />
-        </>,
-        'since-cpp17': <>
-            <Method_SinceCpp17 />
-            The noexcept specification looks as follows:
-            <NoexceptSpecification_SinceCpp11 />
-        </>,
-        'until-cpp17': <Method_UntilCpp17 />
-    }}/>
+		'since-cpp20': <>
+			<Method_SinceCpp20 />
+			The noexcept specification looks as follows:
+			<NoexceptSpecification_SinceCpp11 />
+		</>,
+		'since-cpp17': <>
+			<Method_SinceCpp17 />
+			The noexcept specification looks as follows:
+			<NoexceptSpecification_SinceCpp11 />
+		</>,
+		'until-cpp17': <Method_UntilCpp17 />
+	}}/>
 
 
 Exchanges the contents of the container with those of **other**. Does not invoke any move, copy, or swap operations on individual elements.
@@ -48,11 +50,11 @@ The **past-the-end iterator** is invalidated.
 All other iterators and references remain valid.
 
 <SwitchView content={{
-    'since-cpp11': <>
-        If <code>std::allocator_traits&lt;allocator_type&gt;::propagate_on_container_swap::value</code> is <code>true</code>,
-        then the allocators are exchanged using an unqualified call to non-member swap. 
-        Otherwise, they are not swapped (and if <code>get_allocator() != other.get_allocator()</code>, the behavior is <Tooltip title={Term_UndefinedBehaviour}>undefined</Tooltip>).
-    </>
+	'since-cpp11': <>
+		If <code>std::allocator_traits&lt;allocator_type&gt;::propagate_on_container_swap::value</code> is <code>true</code>,
+		then the allocators are exchanged using an unqualified call to non-member swap. 
+		Otherwise, they are not swapped (and if <code>get_allocator() != other.get_allocator()</code>, the behavior is <Tooltip title={Term_UndefinedBehaviour}>undefined</Tooltip>).
+	</>
 }} />
 
 ### Parameters
@@ -80,28 +82,28 @@ Constant.
 #include <vector>
  
 template<class Os, class Co> Os& operator<<(Os& os, const Co& co) {
-    os << "{";
-    for (auto const& i : co) { os << ' ' << i; }
-    return os << " } ";
+	os << "{";
+	for (auto const& i : co) { os << ' ' << i; }
+	return os << " } ";
 }
  
 int main()
 {
-    std::vector<int> a1{1, 2, 3}, a2{4, 5};
+	std::vector<int> a1{1, 2, 3}, a2{4, 5};
  
-    auto it1 = std::next(a1.begin());
-    auto it2 = std::next(a2.begin());
+	auto it1 = std::next(a1.begin());
+	auto it2 = std::next(a2.begin());
  
-    int& ref1 = a1.front();
-    int& ref2 = a2.front();
+	int& ref1 = a1.front();
+	int& ref2 = a2.front();
  
-    std::cout << a1 << a2 << *it1 << ' ' << *it2 << ' ' << ref1 << ' ' << ref2 << '\n';
-    a1.swap(a2);
-    std::cout << a1 << a2 << *it1 << ' ' << *it2 << ' ' << ref1 << ' ' << ref2 << '\n';
+	std::cout << a1 << a2 << *it1 << ' ' << *it2 << ' ' << ref1 << ' ' << ref2 << '\n';
+	a1.swap(a2);
+	std::cout << a1 << a2 << *it1 << ' ' << *it2 << ' ' << ref1 << ' ' << ref2 << '\n';
  
-    // Note that after swap the iterators and references stay associated with their
-    // original elements, e.g. it1 that pointed to an element in 'a1' with value 2
-    // still points to the same element, though this element was moved into 'a2'.
+	// Note that after swap the iterators and references stay associated with their
+	// original elements, e.g. it1 that pointed to an element in 'a1' with value 2
+	// still points to the same element, though this element was moved into 'a2'.
 }
 ```
 

--- a/content/docs/std/containers/maps/map.mdx
+++ b/content/docs/std/containers/maps/map.mdx
@@ -5,10 +5,12 @@ sidebar_label:		map
 hide_title:			true
 description:		Summary of a std::map (usage, methods, etc.) - C++ Language
 tags:				[map, container, associative, ordered, key, unique]
+
+cppreference_origin_rel: w/cpp/container/map
 ---
 
 import ClassSummary				from "@site-comps/ClassSummary";
-import CustomCodeBlock				from "@site-comps/CustomCodeBlock";
+import CustomCodeBlock			from "@site-comps/CustomCodeBlock";
 import SymbolTable, { Symbol }	from "@site-comps/SymbolTable";
 import Columns					from "@site-comps/Columns";
 import NotFinished				from "@site/i18n/en/presets/NotFinished.mdx";

--- a/content/docs/std/containers/maps/map/at.mdx
+++ b/content/docs/std/containers/maps/map/at.mdx
@@ -4,6 +4,8 @@ sidebar_label:			at( )
 description:			map<...>::at() method C++ documentation
 hide_title:				true
 tags:					[access, map, key, at, element, get]
+
+cppreference_origin_rel: w/cpp/container/map/at
 ---
 
 import Columns					from "@site-comps/Columns";
@@ -59,11 +61,11 @@ auto main() -> int {
 		{ "andrew111", 41 }
 	};
 
-	std::cout << "player1 zdobył " << playersScores.at("player1") << " punktów.\n";
+	std::cout << "player1 gained " << playersScores.at("player1") << " points.\n";
 
 	// Ooops! Incorrect key!
 	// error-next-line
-	std::cout << "super_cader zdobył " << playersScores.at("super_cader") << " punktów.\n";
+	std::cout << "super_cader gained " << playersScores.at("super_cader") << " points.\n";
 }
 ```
 

--- a/content/docs/std/containers/maps/map/begin.mdx
+++ b/content/docs/std/containers/maps/map/begin.mdx
@@ -4,12 +4,14 @@ sidebar_label:			begin( )
 description:			map<...>::begin() C++ documentation
 hide_title:				true
 tags:					[access, iterators, begin, get]
+
+cppreference_origin_rel: w/cpp/container/map/begin
 ---
 
 import SwitchView				from "@site-comps/SwitchView";
 import Columns					from "@site-comps/Columns";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Tooltip					from "@site-comps/Tooltip";
+import Tabs						from "@theme/Tabs";
 import TabItem					from "@theme/TabItem";
 
 <!-- Terms -->

--- a/content/docs/std/containers/maps/map/clear.mdx
+++ b/content/docs/std/containers/maps/map/clear.mdx
@@ -4,23 +4,25 @@ sidebar_label:			clear( )
 description:			map<...>::clear() method C++ documentation
 hide_title:				true
 tags:					[map, clear, empty, erase, remove]
+
+cppreference_origin_rel: w/cpp/container/map/clear
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- clear() -->
-import Method_UntilCpp11 	from './_codes/clear/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/clear/since-cpp11.mdx';
+import Method_UntilCpp11	from './_codes/clear/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/clear/since-cpp11.mdx';
 
 # std::map clear() method
 
 <SwitchView content={{
-        'since-cpp11': <Method_SinceCpp11 />,
-        'until-cpp11': <Method_UntilCpp11 />,
-    }}/>
+	'since-cpp11': <Method_SinceCpp11 />,
+	'until-cpp11': <Method_UntilCpp11 />,
+}}/>
 
 Erases all elements from the container. After this call, [`size()`](/docs/std/containers/maps/map/size) returns zero.
 

--- a/content/docs/std/containers/maps/map/constructors.mdx
+++ b/content/docs/std/containers/maps/map/constructors.mdx
@@ -4,4 +4,6 @@ sidebar_label:			Constructors
 description:			map<...> constructor C++ documentation
 hide_title:				true
 tags:					[constructor, create, initialize, construct]
+
+cppreference_origin_rel: w/cpp/container/map/map
 ---

--- a/content/docs/std/containers/maps/map/contains.mdx
+++ b/content/docs/std/containers/maps/map/contains.mdx
@@ -4,26 +4,28 @@ sidebar_label:			contains( )
 description:			map<...>::contains() method C++ documentation
 hide_title:				true
 tags:					[map, contains, exists]
+
+cppreference_origin_rel: w/cpp/container/map/contains
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- contains() -->
-import Method_SinceCpp20 	from './_codes/contains/since-cpp20.mdx';
+import Method_SinceCpp20	from './_codes/contains/since-cpp20.mdx';
 
 # std::map contains() method
 
 <SwitchView content={{
-    'since-cpp20': <Method_SinceCpp20 />,
-    }} />
+	'since-cpp20': <Method_SinceCpp20 />,
+}} />
 
- - **(1)** Checks if there is an element with key equivalent to `key` in the container.
- - **(2)** Checks if there is an element with key that compares equivalent to the value `x`.
-    This overload participates in overload resolution only if the qualified-id `Compare::is_transparent` is valid and denotes a type.
-    It allows calling this function without constructing an instance of `Key`.
+- **(1)** Checks if there is an element with key equivalent to `key` in the container.
+- **(2)** Checks if there is an element with key that compares equivalent to the value `x`.
+  This overload participates in overload resolution only if the qualified-id `Compare::is_transparent` is valid and denotes a type.
+  It allows calling this function without constructing an instance of `Key`.
 
 ### Parameters
 

--- a/content/docs/std/containers/maps/map/count.mdx
+++ b/content/docs/std/containers/maps/map/count.mdx
@@ -4,22 +4,24 @@ sidebar_label:			count( )
 description:			map<...>::count() method C++ documentation
 hide_title:				true
 tags:					[map, count, exists, contains]
+
+cppreference_origin_rel: w/cpp/container/map/count
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- count() -->
-import Method_SinceCpp98 	from './_codes/count/since-cpp98.mdx';
-import Method_SinceCpp14 	from './_codes/count/since-cpp14.mdx';
+import Method_SinceCpp98	from './_codes/count/since-cpp98.mdx';
+import Method_SinceCpp14	from './_codes/count/since-cpp14.mdx';
 
 # std::map count() method
 
 <SwitchView content={{
-    'since-cpp14': <Method_SinceCpp14 />,
-    'since-cpp98': <Method_SinceCpp98 />,
-    }} />
+	'since-cpp14': <Method_SinceCpp14 />,
+	'since-cpp98': <Method_SinceCpp98 />,
+}} />
 
 Returns the number of elements with key that compares equivalent to the specified argument, which is either **1** or **0** since this container does not allow duplicates.
 

--- a/content/docs/std/containers/maps/map/destructor.mdx
+++ b/content/docs/std/containers/maps/map/destructor.mdx
@@ -4,15 +4,17 @@ sidebar_label:			Destructor
 description:			map<...> destructor C++ documentation
 hide_title:				true
 tags:					[destructor, destroy]
+
+cppreference_origin_rel: w/cpp/container/map/~map
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- destructors -->
 
-import Method_SinceCpp98 	from './_codes/destructors/since-cpp98.mdx';
+import Method_SinceCpp98	from './_codes/destructors/since-cpp98.mdx';
 
 # std::map destructors
 

--- a/content/docs/std/containers/maps/map/emplace.mdx
+++ b/content/docs/std/containers/maps/map/emplace.mdx
@@ -4,12 +4,14 @@ sidebar_label:			emplace( )
 description:			map<...>::emplace() method C++ documentation
 hide_title:				true
 tags:					[map, emplace, insert, add]
+
+cppreference_origin_rel: w/cpp/container/map/emplace
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/map/emplace_hint.mdx
+++ b/content/docs/std/containers/maps/map/emplace_hint.mdx
@@ -4,23 +4,25 @@ sidebar_label:			emplace_hint( )
 description:			map<...>::emplace_hint() method C++ documentation
 hide_title:				true
 tags:					[map, emplace_hint, insert, add]
+
+cppreference_origin_rel: w/cpp/container/map/emplace_hint
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
 
 <!----------------- Codes ---------------------->
 
 <!-- emplace_hint() -->
-import Method_SinceCpp11 	from './_codes/emplace_hint/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/emplace_hint/since-cpp11.mdx';
 
 # std::map emplace_hint() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Inserts a new element to the container as close as possible to the position just before `hint`.
 The element is constructed in-place, i.e. no copy or move operations are performed.

--- a/content/docs/std/containers/maps/map/empty.mdx
+++ b/content/docs/std/containers/maps/map/empty.mdx
@@ -4,25 +4,27 @@ sidebar_label:			empty( )
 description:			map<...>::empty() method C++ documentation
 hide_title:				true
 tags:					[empty, size]
+
+cppreference_origin_rel: w/cpp/container/map/empty
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- empty() -->
-import Method_UntilCpp11 	from './_codes/empty/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/empty/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/empty/since-cpp20.mdx';
+import Method_UntilCpp11	from './_codes/empty/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/empty/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/empty/since-cpp20.mdx';
 
 # std::vector empty() method
 
 <SwitchView content={{
-        'since-cpp20': <Method_SinceCpp20 />,
-        'since-cpp11': <Method_SinceCpp11 />,
-        'until-cpp11': <Method_UntilCpp11 />,
-    }}/>
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+	'until-cpp11': <Method_UntilCpp11 />,
+}}/>
 
 
 Checks if the container has no elements, i.e. whether `begin() == end()`.

--- a/content/docs/std/containers/maps/map/end.mdx
+++ b/content/docs/std/containers/maps/map/end.mdx
@@ -4,24 +4,26 @@ sidebar_label:			end( )
 description:			map<...>::end() C++ documentation
 hide_title:				true
 tags:					[access, iterators, end, get]
+
+cppreference_origin_rel: w/cpp/container/map/end
 ---
 
 import SwitchView				from "@site-comps/SwitchView";
 import Columns					from "@site-comps/Columns";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Tooltip					from "@site-comps/Tooltip";
+import Tabs						from "@theme/Tabs";
 import TabItem					from "@theme/TabItem";
 
 <!-- Terms -->
-import Term_ContAlias_Iterator from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";
-import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
+import Term_ContAlias_Iterator	from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";
+import Term_UndefinedBehaviour	from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- end -->
 
-import Method_UntilCpp11 	from './_codes/end/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/end/since-cpp11.mdx';
+import Method_UntilCpp11		from './_codes/end/until-cpp11.mdx';
+import Method_SinceCpp11		from './_codes/end/since-cpp11.mdx';
 
 # std::map end() method
 

--- a/content/docs/std/containers/maps/map/equal_range.mdx
+++ b/content/docs/std/containers/maps/map/equal_range.mdx
@@ -4,32 +4,34 @@ sidebar_label:			equal_range( )
 description:			map<...>::equal_range() method C++ documentation
 hide_title:				true
 tags:					[map, equal_range, compare, equal, range]
+
+cppreference_origin_rel: w/cpp/container/map/equal_range
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- equal_range() -->
-import Method_SinceCpp98 	from './_codes/equal_range/since-cpp98.mdx';
-import Method_SinceCpp14 	from './_codes/equal_range/since-cpp14.mdx';
+import Method_SinceCpp98	from './_codes/equal_range/since-cpp98.mdx';
+import Method_SinceCpp14	from './_codes/equal_range/since-cpp14.mdx';
 
 # std::map equal_range() method
 
 <SwitchView content={{
-    'since-cpp14': <Method_SinceCpp14 />,
-    'since-cpp98': <Method_SinceCpp98 />,
-    }} />
+	'since-cpp14': <Method_SinceCpp14 />,
+	'since-cpp98': <Method_SinceCpp98 />,
+}} />
 
 Returns a range containing all elements with the given key in the container. 
 The range is defined by two iterators, one pointing to the first element that is not less than `key` and another pointing to the first element greater than `key`.
 Alternatively, the first iterator may be obtained with [`lower_bound()`](/docs/std/containers/maps/map/lower_bound), and the second with [`upper_bound()`](/docs/std/containers/maps/map/upper_bound).
 
- - **(1-2)** Compares the keys to `key`.
- - **(3-4)** Compares the keys to the value `x`.
-    This overload participates in overload resolution only if the qualified-id `Compare::is_transparent` is valid and denotes a type.
-    It allows calling this function without constructing an instance of `Key`.
+- **(1-2)** Compares the keys to `key`.
+- **(3-4)** Compares the keys to the value `x`.
+  This overload participates in overload resolution only if the qualified-id `Compare::is_transparent` is valid and denotes a type.
+  It allows calling this function without constructing an instance of `Key`.
 
 ### Parameters
 

--- a/content/docs/std/containers/maps/map/erase.mdx
+++ b/content/docs/std/containers/maps/map/erase.mdx
@@ -4,17 +4,19 @@ sidebar_label:			erase( )
 description:			map<...>::erase() method C++ documentation
 hide_title:				true
 tags:					[map, remove, erase, delete]
+
+cppreference_origin_rel: w/cpp/container/map/erase
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- erase() -->
-import Method_UntilCpp11 	from './_codes/erase/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/erase/since-cpp11.mdx';
-import Method_SinceCpp23 	from './_codes/erase/since-cpp23.mdx';
+import Method_UntilCpp11	from './_codes/erase/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/erase/since-cpp11.mdx';
+import Method_SinceCpp23	from './_codes/erase/since-cpp23.mdx';
 
 # std::map erase() method
 
@@ -30,8 +32,8 @@ Removes specified elements from the container.
 - **(2)** Removes the elements in the range **[ first; last )**, which must be a valid range in `*this`.
 - **(3)** Removes the element (if one exists) with the key equivalent to `key`.
 - **(4)** Removes the element (if one exists) with key that compares equivalent to the value `x`.
-    This overload participates in overload resolution only if the qualified-id `Compare::is_transparent` is valid and denotes a type,
-    and neither `iterator` nor `const_iterator` is implicitly convertible from `K`. It allows calling this function without constructing an instance of `Key`.
+  This overload participates in overload resolution only if the qualified-id `Compare::is_transparent` is valid and denotes a type,
+  and neither `iterator` nor `const_iterator` is implicitly convertible from `K`. It allows calling this function without constructing an instance of `Key`.
 
 :::danger Invalidation
 **References** and **iterators** to the erased elements are invalidated. Other references and iterators are not affected.

--- a/content/docs/std/containers/maps/map/extract.mdx
+++ b/content/docs/std/containers/maps/map/extract.mdx
@@ -4,29 +4,31 @@ sidebar_label:			extract( )
 description:			map<...>::extract() method C++ documentation
 hide_title:				true
 tags:					[map, extract]
+
+cppreference_origin_rel: w/cpp/container/map/extract
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- extract() -->
-import Method_SinceCpp17 	from './_codes/extract/since-cpp17.mdx';
-import Method_SinceCpp23 	from './_codes/extract/since-cpp23.mdx';
+import Method_SinceCpp17	from './_codes/extract/since-cpp17.mdx';
+import Method_SinceCpp23	from './_codes/extract/since-cpp23.mdx';
 
 # std::map extract() method
 
 <SwitchView content={{
-		'since-cpp23': <Method_SinceCpp23 />,
-		'since-cpp17': <Method_SinceCpp17 />,
-	}}/>
+	'since-cpp23': <Method_SinceCpp23 />,
+	'since-cpp17': <Method_SinceCpp17 />,
+}}/>
 
- - **(1)** Unlinks the node that contains the element pointed to by position and returns a node handle that owns it.
- - **(2)** If the container has an element with key equivalent to `k`, unlinks the node that contains that element from the container and returns a node handle that owns it.
-    Otherwise, returns an empty node handle.
- - **(3)** Same as **(2)**. This overload participates in overload resolution only if the qualified-id `Compare::is_transparent` is valid and denotes a type,
-    and neither `iterator` nor `const_iterator` is implicitly convertible from `K`. It allows calling this function without constructing an instance of `Key`.
+- **(1)** Unlinks the node that contains the element pointed to by position and returns a node handle that owns it.
+- **(2)** If the container has an element with key equivalent to `k`, unlinks the node that contains that element from the container and returns a node handle that owns it.
+  Otherwise, returns an empty node handle.
+- **(3)** Same as **(2)**. This overload participates in overload resolution only if the qualified-id `Compare::is_transparent` is valid and denotes a type,
+  and neither `iterator` nor `const_iterator` is implicitly convertible from `K`. It allows calling this function without constructing an instance of `Key`.
 
 In either case, no elements are copied or moved, only the internal pointers of the container nodes are repointed (rebalancing may occur, as with [`erase()`](/docs/std/containers/maps/map/erase)).
 

--- a/content/docs/std/containers/maps/map/find.mdx
+++ b/content/docs/std/containers/maps/map/find.mdx
@@ -4,10 +4,12 @@ sidebar_label:			find( )
 description:			map<...>::find() method C++ documentation
 hide_title:				true
 tags:					[map, find, exists, contains, get]
+
+cppreference_origin_rel: w/cpp/container/map/find
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
@@ -18,14 +20,14 @@ import Method_SinceCpp14 	from './_codes/find/since-cpp14.mdx';
 # std::map find() method
 
 <SwitchView content={{
-    'since-cpp14': <Method_SinceCpp14 />,
-    'since-cpp98': <Method_SinceCpp98 />,
-    }} />
+	'since-cpp14': <Method_SinceCpp14 />,
+	'since-cpp98': <Method_SinceCpp98 />,
+}} />
 
- - **(1-2)** Finds an element with key equivalent to `key`.
- - **(3-4)** Finds an element with key that compares equivalent to the value `x`.
-    This overload participates in overload resolution only if the qualified-id `Compare::is_transparent` is valid and denotes a type.
-    It allows calling this function without constructing an instance of `Key`.
+- **(1-2)** Finds an element with key equivalent to `key`.
+- **(3-4)** Finds an element with key that compares equivalent to the value `x`.
+  This overload participates in overload resolution only if the qualified-id `Compare::is_transparent` is valid and denotes a type.
+  It allows calling this function without constructing an instance of `Key`.
 
 ### Parameters
 

--- a/content/docs/std/containers/maps/map/get_allocator.mdx
+++ b/content/docs/std/containers/maps/map/get_allocator.mdx
@@ -4,9 +4,11 @@ sidebar_label:			get_allocator
 description:			map<...>::get_allocator C++ documentation
 hide_title:				true
 tags:					[allocator, get]
+
+cppreference_origin_rel: w/cpp/container/map/get_allocator
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/map/insert.mdx
+++ b/content/docs/std/containers/maps/map/insert.mdx
@@ -4,13 +4,15 @@ sidebar_label:			insert( )
 description:			map<...>::insert() method C++ documentation
 hide_title:				true
 tags:					[map, insert, add]
+
+cppreference_origin_rel: w/cpp/container/map/insert
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import ImproveSection			from "@site/i18n/en/presets/ImproveSection.mdx";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!-- Terms -->
 import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
@@ -35,63 +37,66 @@ import IteratorDereferenceNote 	from './_codes/insert/explanation/iterator-deref
 
 Inserts element(s) into the container, if the container doesn't already contain an element with an equivalent key.
 
- - **(1-3)** Inserts value.
-    The overload **(2)** is equivalent to `emplace(std::forward<P>(value))` and only participates in overload resolution if `std::is_constructible<value_type, P&&>::value == true`.
- - **(4-6)** Inserts value in the position as close as possible, just prior, to hint.
-    The overload **(5)** is equivalent to `emplace_hint(hint, std::forward<P>(value))` and only participates in overload resolution if `std::is_constructible<value_type, P&&>::value == true`.
- - **(7)** Inserts elements from range **[ first, last )**. If multiple elements in the range have keys that compare equivalent, it is unspecified which element is inserted (pending **LWG2844**).
- - **(8)** Inserts elements from initializer list `ilist`. If multiple elements in the range have keys that compare equivalent, it is unspecified which element is inserted (pending **LWG2844**).
- - **(9)** If `nh` is an empty node handle, does nothing. Otherwise, inserts the element owned by `nh` into the container,
-    if the container doesn't already contain an element with a key equivalent to `nh.key()`. The behavior is undefined if `nh` is not empty and `get_allocator() != nh.get_allocator()`.
- - **(10)** If `nh` is an empty node handle, does nothing and returns the end iterator.
-    Otherwise, inserts the element owned by `nh` into the container, if the container doesn't already contain an element with a key equivalent to `n.key()`,
-    and returns the iterator pointing to the element with key equivalent to `nh.key()` (regardless of whether the insert succeeded or failed).
-    If the insertion succeeds, `nh` is moved from, otherwise it retains ownership of the element.
-    The element is inserted as close as possible to the position just prior to hint. The behavior is undefined if `nh` is not empty and `get_allocator() != nh.get_allocator()`.
+- **(1-3)** Inserts value.
+  The overload **(2)** is equivalent to `emplace(std::forward<P>(value))` and only participates in overload resolution if `std::is_constructible<value_type, P&&>::value == true`.
+- **(4-6)** Inserts value in the position as close as possible, just prior, to hint.
+  The overload **(5)** is equivalent to `emplace_hint(hint, std::forward<P>(value))` and only participates in overload resolution if `std::is_constructible<value_type, P&&>::value == true`.
+- **(7)** Inserts elements from range **[ first, last )**. If multiple elements in the range have keys that compare equivalent, it is unspecified which element is inserted (pending **LWG2844**).
+- **(8)** Inserts elements from initializer list `ilist`. If multiple elements in the range have keys that compare equivalent, it is unspecified which element is inserted (pending **LWG2844**).
+- **(9)** If `nh` is an empty node handle, does nothing. Otherwise, inserts the element owned by `nh` into the container,
+  if the container doesn't already contain an element with a key equivalent to `nh.key()`. 
+  <span className="inline-danger">The behavior is undefined if <code>nh</code> is not empty and <code>get_allocator() != nh.get_allocator()</code>.</span>
+
+- **(10)** If `nh` is an empty node handle, does nothing and returns the end iterator.
+  Otherwise, inserts the element owned by `nh` into the container, if the container doesn't already contain an element with a key equivalent to `n.key()`,
+  and returns the iterator pointing to the element with key equivalent to `nh.key()` (regardless of whether the insert succeeded or failed).
+  If the insertion succeeds, `nh` is moved from, otherwise it retains ownership of the element.
+  The element is inserted as close as possible to the position just prior to hint. 
+  <span className="inline-danger">The behavior is undefined if <code>nh</code> is not empty and <code>get_allocator() != nh.get_allocator()</code>.</span>
 
 <SwitchView content={{
-    'since-cpp17': <> No iterators or references are invalidated. </>,
-    'until-cpp11': <IteratorDereferenceNote />,
-    }} />
+	'since-cpp17': <> No iterators or references are invalidated. </>,
+	'until-cpp11': <IteratorDereferenceNote />,
+}} />
 
 ### Parameters
 
  - `hint`
 <SwitchView content={{
-    'since-cpp11': <> iterator to the position before which the new element will be inserted </>,
-    'until-cpp11': <> iterator, used as a suggestion as to where to start the search </>,
-    }} />
- - `value` - element value to insert
- - `count` - number of elements to insert
- - `first`, `last` - the range of elements to insert
- - `ilist` - initializer list to insert the values from
- - `nh` - a compatible node handle
+	'since-cpp11': <> iterator to the position before which the new element will be inserted </>,
+	'until-cpp11': <> iterator, used as a suggestion as to where to start the search </>,
+}} />
+- `value` - element value to insert
+- `count` - number of elements to insert
+- `first`, `last` - the range of elements to insert
+- `ilist` - initializer list to insert the values from
+- `nh` - a compatible node handle
  
 ### Type requirements
- - **(7)** `InputIt` must meet the requirements of [`LegacyInputIterator`](/docs/named_req/LegacyInputIterator).
+- **(7)** `InputIt` must meet the requirements of [`LegacyInputIterator`](/docs/named_req/LegacyInputIterator).
 
 ### Return value
 
- - **(1-3)** Returns a pair consisting of an iterator to the inserted element (or to the element that prevented the insertion) and a `bool` denoting whether the insertion took place.
- - **(4-6)** Returns an iterator to the inserted element, or to the element that prevented the insertion.
- - **(7-8)** **(none)**
- - **(9)** Returns an `insert_return_type` with the members initialized as follows:
-    - If `nh` is empty, `inserted` is `false`, `position` is [`end()`](/docs/std/containers/maps/map/end), and `node` is `empty`.
-    - Otherwise if the insertion took place, `inserted` is `true`, `position` points to the inserted element, and `node` is `empty`.
-    - If the insertion failed, `inserted` is `false`, `node` has the previous value of nh, and `position` points to an element with a key equivalent to `nh.key()`.
- = **(10)** End iterator if `nh` was empty, iterator pointing to the inserted element if insertion took place, and iterator pointing to an element with a key equivalent to `nh.key()` if it failed.
+- **(1-3)** Returns a pair consisting of an iterator to the inserted element (or to the element that prevented the insertion) and a `bool` denoting whether the insertion took place.
+- **(4-6)** Returns an iterator to the inserted element, or to the element that prevented the insertion.
+- **(7-8)** **(none)**
+- **(9)** Returns an `insert_return_type` with the members initialized as follows:
+  - If `nh` is empty, `inserted` is `false`, `position` is [`end()`](/docs/std/containers/maps/map/end), and `node` is `empty`.
+  - Otherwise if the insertion took place, `inserted` is `true`, `position` points to the inserted element, and `node` is `empty`.
+  - If the insertion failed, `inserted` is `false`, `node` has the previous value of nh, and `position` points to an element with a key equivalent to `nh.key()`.
+- **(10)** End iterator if `nh` was empty, iterator pointing to the inserted element if insertion took place, and iterator pointing to an element with a key equivalent to `nh.key()` if it failed.
 
 ### Complexity
 
- - **(1-3)** Logarithmic in the size of the container - **O(log size())**.
- - **(4-6)** 
+- **(1-3)** Logarithmic in the size of the container - **O(log size())**.
+- **(4-6)** 
 <SwitchView content={{
 	'since-cpp11': <> Amortized constant if the insertion happens in the position just before the hint, logarithmic in the size of the container otherwise - <b>O(1)</b>.</>,
 	'until-cpp11': <> Amortized constant if the insertion happens in the position just after the hint, logarithmic in the size of the container otherwise - <b>O(1)</b>.</>,
     }} />
- - **(7-8)** **O(N * log(size() + N))**, where **N** is the number of elements to insert.
- - **(9)** Logarithmic in the size of the container - **O(log size())**.
- - **(10)**  
+- **(7-8)** **O(N * log(size() + N))**, where **N** is the number of elements to insert.
+- **(9)** Logarithmic in the size of the container - **O(log size())**.
+- **(10)**  
 Amortized constant if the insertion happens in the position **just before** the hint - **O(1)**  .
 Logarithmic in the size of the container otherwise - **O(log size())**.
 

--- a/content/docs/std/containers/maps/map/insert_or_assign.mdx
+++ b/content/docs/std/containers/maps/map/insert_or_assign.mdx
@@ -4,13 +4,15 @@ sidebar_label:			insert_or_assign( )
 description:			map<...>::insert_or_assign() method C++ documentation
 hide_title:				true
 tags:					[map, insert_or_assign, assign, insert, add]
+
+cppreference_origin_rel: w/cpp/container/map/insert_or_assign
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import ImproveSection			from "@site/i18n/en/presets/ImproveSection.mdx";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/map/key_comp.mdx
+++ b/content/docs/std/containers/maps/map/key_comp.mdx
@@ -4,10 +4,12 @@ sidebar_label:			key_comp( )
 description:			map<...>::key_comp() method C++ documentation
 hide_title:				true
 tags:					[compare, key_comp, key, comp]
+
+cppreference_origin_rel: w/cpp/container/map/key_comp
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
@@ -17,8 +19,8 @@ import Method_SinceCpp98 	from './_codes/key_comp/since-cpp98.mdx';
 # std::map key_comp() method
 
 <SwitchView content={{
-    'since-cpp98': <Method_SinceCpp98 />,
-    }} />
+	'since-cpp98': <Method_SinceCpp98 />,
+}} />
 
 Returns the function object that compares the keys, which is a copy of this container's [`constructor`](/docs/std/containers/maps/map/constructors) argument `comp`.
 

--- a/content/docs/std/containers/maps/map/lower_bound.mdx
+++ b/content/docs/std/containers/maps/map/lower_bound.mdx
@@ -4,10 +4,12 @@ sidebar_label:			lower_bound( )
 description:			map<...>::lower_bound() method C++ documentation
 hide_title:				true
 tags:					[map, lower_bound, less]
+
+cppreference_origin_rel: w/cpp/container/map/lower_bound
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/map/max_size.mdx
+++ b/content/docs/std/containers/maps/map/max_size.mdx
@@ -4,23 +4,25 @@ sidebar_label:			max_size( )
 description:			map<...>::max_size() method C++ documentation
 hide_title:				true
 tags:					[max, size, max_size]
+
+cppreference_origin_rel: w/cpp/container/map/max_size
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- max_size() -->
-import Method_UntilCpp11 	from './_codes/max_size/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/max_size/since-cpp11.mdx';
+import Method_UntilCpp11	from './_codes/max_size/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/max_size/since-cpp11.mdx';
 
 # std::map max_size() method
 
 <SwitchView content={{
-        'since-cpp11': <Method_SinceCpp11 />,
-        'until-cpp11': <Method_UntilCpp11 />,
-    }}/>
+	'since-cpp11': <Method_SinceCpp11 />,
+	'until-cpp11': <Method_UntilCpp11 />,
+}}/>
 
 		
 Returns the **maximum number of elements** the container is able to hold due to system or library implementation limitations,

--- a/content/docs/std/containers/maps/map/merge.mdx
+++ b/content/docs/std/containers/maps/map/merge.mdx
@@ -4,13 +4,15 @@ sidebar_label:			merge( )
 description:			map<...>::merge() method C++ documentation
 hide_title:				true
 tags:					[map, merge, add, copy]
+
+cppreference_origin_rel: w/cpp/container/map/merge
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import ImproveSection			from "@site/i18n/en/presets/ImproveSection.mdx";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!-- Terms -->
 import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";

--- a/content/docs/std/containers/maps/map/operator_assign.mdx
+++ b/content/docs/std/containers/maps/map/operator_assign.mdx
@@ -4,6 +4,8 @@ sidebar_label:			operator=
 description:			map<...>::operator= C++ documentation
 hide_title:				true
 tags:					[assign, replace, copy, set]
+
+cppreference_origin_rel: w/cpp/container/map/operator=
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/maps/map/operator_subscript.mdx
+++ b/content/docs/std/containers/maps/map/operator_subscript.mdx
@@ -4,6 +4,8 @@ sidebar_label:			operator[]
 description:			map<...>::operator[] C++ documentation
 hide_title:				true
 tags:					[subscript, access, map, key]
+
+cppreference_origin_rel: w/cpp/container/map/operator_at
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/maps/map/rbegin.mdx
+++ b/content/docs/std/containers/maps/map/rbegin.mdx
@@ -4,13 +4,15 @@ sidebar_label:			rbegin( )
 description:		    map<...>::rbegin() method C++ documentation
 hide_title:				true
 tags:					[access, map, iterator, reverse, rbegin, begin]
+
+cppreference_origin_rel: w/cpp/container/map/rbegin
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import TabItem					from "@theme/TabItem";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
+import TabItem				from "@theme/TabItem";
 
 <!-- Terms -->
 import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
@@ -24,9 +26,9 @@ import Method_SinceCpp11 	from './_codes/rbegin/since-cpp11.mdx';
 # std::vector rbegin() method
 
 <SwitchView content={{
-        'since-cpp11': <Method_SinceCpp11 />,
-        'until-cpp11': <Method_UntilCpp11 />,
-    }}/>
+	'since-cpp11': <Method_SinceCpp11 />,
+	'until-cpp11': <Method_UntilCpp11 />,
+}}/>
 
 Returns a <Tooltip title={Term_ContAlias_ReverseIterator}>reverse iterator</Tooltip> to the first element of the reversed vector.
 It corresponds to the last element of the non-reversed vector.

--- a/content/docs/std/containers/maps/map/rend.mdx
+++ b/content/docs/std/containers/maps/map/rend.mdx
@@ -4,17 +4,19 @@ sidebar_label:			rend( )
 description:			map<...>::rend() method C++ documentation
 hide_title:				true
 tags:					[access, map, rend, end]
+
+cppreference_origin_rel: w/cpp/container/map/rend
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import TabItem					from "@theme/TabItem";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
+import TabItem				from "@theme/TabItem";
 
 <!-- Terms -->
-import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
-import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
+import Term_ContAlias_ReverseIterator	from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
+import Term_UndefinedBehaviour			from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/map/size.mdx
+++ b/content/docs/std/containers/maps/map/size.mdx
@@ -4,23 +4,25 @@ sidebar_label:			size( )
 description:			map<...>::size() method C++ documentation
 hide_title:				true
 tags:					[size]
+
+cppreference_origin_rel: w/cpp/container/map/size
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- size() -->
-import Method_UntilCpp11 	from './_codes/size/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/size/since-cpp11.mdx';
+import Method_UntilCpp11	from './_codes/size/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/size/since-cpp11.mdx';
 
 # std::map size() method
 
 <SwitchView content={{
-        'since-cpp11': <Method_SinceCpp11 />,
-        'until-cpp11': <Method_UntilCpp11 />,
-    }}/>
+	'since-cpp11': <Method_SinceCpp11 />,
+	'until-cpp11': <Method_UntilCpp11 />,
+}}/>
 
 Returns the number of elements in the container, i.e. `std::distance(begin(), end())`.
 

--- a/content/docs/std/containers/maps/map/swap.mdx
+++ b/content/docs/std/containers/maps/map/swap.mdx
@@ -4,6 +4,8 @@ sidebar_label:			swap( )
 description:			map<...>::swap() method C++ documentation
 hide_title:				true
 tags:					[map, swap]
+
+cppreference_origin_rel: w/cpp/container/map/swap
 ---
 
 import Columns					from "@site-comps/Columns";
@@ -12,9 +14,8 @@ import SwitchView				from "@site-comps/SwitchView";
 <!----------------- Codes ---------------------->
 
 <!-- swap() -->
-import Method_UntilCpp17 	from './_codes/swap/until-cpp17.mdx';
-import Method_SinceCpp17 	from './_codes/swap/since-cpp17.mdx';
-
+import Method_UntilCpp17		from './_codes/swap/until-cpp17.mdx';
+import Method_SinceCpp17		from './_codes/swap/since-cpp17.mdx';
 import NoexceptSpecification 	from './_codes/swap/noexcept-specification/since-cpp17.mdx';
 
 # std::map swap() method

--- a/content/docs/std/containers/maps/map/try_emplace.mdx
+++ b/content/docs/std/containers/maps/map/try_emplace.mdx
@@ -4,23 +4,25 @@ sidebar_label:			try_emplace( )
 description:			map<...>::try_emplace() method C++ documentation
 hide_title:				true
 tags:					[map, try_emplace, insert, add]
+
+cppreference_origin_rel: w/cpp/container/map/try_emplace
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
 
 <!----------------- Codes ---------------------->
 
 <!-- try_emplace() -->
-import Method_SinceCpp17 	from './_codes/try_emplace/since-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/try_emplace/since-cpp17.mdx';
 
 # std::map try_emplace() method
 
 <SwitchView content={{
-    'since-cpp17': <Method_SinceCpp17 />,
-    }} />
+	'since-cpp17': <Method_SinceCpp17 />,
+}} />
 
 Inserts a new element into the container with key `k` and value constructed with `args`, if there is no element with the key in the container.
 

--- a/content/docs/std/containers/maps/map/upper_bound.mdx
+++ b/content/docs/std/containers/maps/map/upper_bound.mdx
@@ -4,16 +4,18 @@ sidebar_label:			upper_bound( )
 description:			map<...>::upper_bound() method C++ documentation
 hide_title:				true
 tags:					[map, upper_bound, more, greater]
+
+cppreference_origin_rel: w/cpp/container/map/upper_bound
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- upper_bound() -->
-import Method_SinceCpp98 	from './_codes/upper_bound/since-cpp98.mdx';
-import Method_SinceCpp14 	from './_codes/upper_bound/since-cpp14.mdx';
+import Method_SinceCpp98	from './_codes/upper_bound/since-cpp98.mdx';
+import Method_SinceCpp14	from './_codes/upper_bound/since-cpp14.mdx';
 
 # std::map upper_bound() method
 

--- a/content/docs/std/containers/maps/map/value_comp.mdx
+++ b/content/docs/std/containers/maps/map/value_comp.mdx
@@ -4,6 +4,8 @@ sidebar_label:			value_comp( )
 description:			map<...>::value_comp() method C++ documentation
 hide_title:				true
 tags:					[compare, value_comp, value, comp]
+
+cppreference_origin_rel: w/cpp/container/map/value_comp
 ---
 
 import Columns					from "@site-comps/Columns";
@@ -17,8 +19,8 @@ import Method_SinceCpp98 	from './_codes/value_comp/since-cpp98.mdx';
 # std::map value_comp() method
 
 <SwitchView content={{
-    'since-cpp98': <Method_SinceCpp98 />,
-    }} />
+	'since-cpp98': <Method_SinceCpp98 />,
+}} />
 
 Returns a function object that compares objects of type `value_type` (key-value pairs) by using [`key_comp()`](/docs/std/containers/maps/map/key_comp) to compare the first components of the pairs.
 

--- a/content/docs/std/containers/maps/map/value_compare.mdx
+++ b/content/docs/std/containers/maps/map/value_compare.mdx
@@ -4,6 +4,8 @@ sidebar_label:			value_compare
 description:			map<...>::value_compare member class C++ documentation
 hide_title:				true
 tags:					[compare, member, value_comp, value, comp]
+
+cppreference_origin_rel: w/cpp/container/map/value_compare
 ---
 
 import Columns					from "@site-comps/Columns";
@@ -12,16 +14,16 @@ import SymbolTable, { Symbol }	from "@site-comps/SymbolTable";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp98 	from './_codes/value_compare/since-cpp98.mdx';
+import Method_SinceCpp98		from './_codes/value_compare/since-cpp98.mdx';
 
-import ValueComp_Constructor 	from './_codes/value_compare/other/value-comp-constructor.mdx';
-import ValueComp_CallOperator 	from './_codes/value_compare/other/value-comp-call-operator.mdx';
+import ValueComp_Constructor	from './_codes/value_compare/other/value-comp-constructor.mdx';
+import ValueComp_CallOperator	from './_codes/value_compare/other/value-comp-call-operator.mdx';
 
 # std::map value_compare
 
 <SwitchView content={{
-    'since-cpp98': <Method_SinceCpp98 />,
-    }} />
+	'since-cpp98': <Method_SinceCpp98 />,
+}} />
 
 `value_compare` is a function object that compares objects of type `value_type` (key-value pairs) by comparing of the first components of the pairs.
 

--- a/content/docs/std/containers/maps/multimap.mdx
+++ b/content/docs/std/containers/maps/multimap.mdx
@@ -5,10 +5,12 @@ sidebar_label:		multimap
 hide_title:			true
 description:		Summary of a std::multimap (usage, methods, etc.) - C++ Language
 tags:				[multimap, container, associative, ordered, multi, key]
+
+cppreference_origin_rel: w/cpp/container/multimap
 ---
 
 import ClassSummary				from "@site-comps/ClassSummary";
-import CustomCodeBlock				from "@site-comps/CustomCodeBlock";
+import CustomCodeBlock			from "@site-comps/CustomCodeBlock";
 import SymbolTable, { Symbol }	from "@site-comps/SymbolTable";
 import Columns					from "@site-comps/Columns";
 import NotFinished				from "@site/i18n/en/presets/NotFinished.mdx";

--- a/content/docs/std/containers/maps/multimap/begin.mdx
+++ b/content/docs/std/containers/maps/multimap/begin.mdx
@@ -4,6 +4,8 @@ sidebar_label:			begin( )
 description:			multimap<...>::begin() C++ documentation
 hide_title:				true
 tags:					[access, iterators, begin, get]
+
+cppreference_origin_rel: w/cpp/container/multimap/begin
 ---
 
 import SwitchView				from "@site-comps/SwitchView";

--- a/content/docs/std/containers/maps/multimap/clear.mdx
+++ b/content/docs/std/containers/maps/multimap/clear.mdx
@@ -4,6 +4,8 @@ sidebar_label:			clear( )
 description:			map<...>::clear() method C++ documentation
 hide_title:				true
 tags:					[map, clear, empty, erase, remove]
+
+cppreference_origin_rel: w/cpp/container/multimap/clear
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/maps/multimap/constructors.mdx
+++ b/content/docs/std/containers/maps/multimap/constructors.mdx
@@ -4,4 +4,6 @@ sidebar_label:			Constructors
 description:			mutlimap<...> constructors C++ documentation
 hide_title:				true
 tags:					[constructor, constructors, construct, initialize]
+
+cppreference_origin_rel: w/cpp/container/multimap/multimap
 ---

--- a/content/docs/std/containers/maps/multimap/contains.mdx
+++ b/content/docs/std/containers/maps/multimap/contains.mdx
@@ -4,10 +4,12 @@ sidebar_label:			contains( )
 description:			map<...>::contains() method C++ documentation
 hide_title:				true
 tags:					[map, contains, exists]
+
+cppreference_origin_rel: w/cpp/container/multimap/contains
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/multimap/count.mdx
+++ b/content/docs/std/containers/maps/multimap/count.mdx
@@ -4,15 +4,17 @@ sidebar_label:			count( )
 description:			map<...>::count() method C++ documentation
 hide_title:				true
 tags:					[map, count, exists, contains]
+
+cppreference_origin_rel: w/cpp/container/multimap/count
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- count() -->
-import Method_SinceCpp98 	from './_codes/count/since-cpp98.mdx';
-import Method_SinceCpp14 	from './_codes/count/since-cpp14.mdx';
+import Method_SinceCpp98	from './_codes/count/since-cpp98.mdx';
+import Method_SinceCpp14	from './_codes/count/since-cpp14.mdx';
 
 # std::multimap count() method
 

--- a/content/docs/std/containers/maps/multimap/destructor.mdx
+++ b/content/docs/std/containers/maps/multimap/destructor.mdx
@@ -4,15 +4,17 @@ sidebar_label:			Destructor
 description:			mutlimap<...> destructor C++ documentation
 hide_title:				true
 tags:					[destructor, destroy]
+
+cppreference_origin_rel: w/cpp/container/multimap/~multimap
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- destructors -->
 
-import Method_SinceCpp98 	from './_codes/destructors/since-cpp98.mdx';
+import Method_SinceCpp98	from './_codes/destructors/since-cpp98.mdx';
 
 # std::multimap destructors
 

--- a/content/docs/std/containers/maps/multimap/emplace.mdx
+++ b/content/docs/std/containers/maps/multimap/emplace.mdx
@@ -4,6 +4,8 @@ sidebar_label:			emplace( )
 description:			map<...>::emplace() method C++ documentation
 hide_title:				true
 tags:					[map, emplace, insert, add]
+
+cppreference_origin_rel: w/cpp/container/multimap/emplace
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/maps/multimap/emplace_hint.mdx
+++ b/content/docs/std/containers/maps/multimap/emplace_hint.mdx
@@ -4,6 +4,8 @@ sidebar_label:			emplace_hint( )
 description:			map<...>::emplace_hint() method C++ documentation
 hide_title:				true
 tags:					[map, emplace_hint, insert, add]
+
+cppreference_origin_rel: w/cpp/container/multimap/emplace_hint
 ---
 
 import SwitchView				from "@site-comps/SwitchView";

--- a/content/docs/std/containers/maps/multimap/empty.mdx
+++ b/content/docs/std/containers/maps/multimap/empty.mdx
@@ -4,6 +4,8 @@ sidebar_label:			empty( )
 description:			multimap<...>::empty() method C++ documentation
 hide_title:				true
 tags:					[empty, size]
+
+cppreference_origin_rel: w/cpp/container/multimap/empty
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/maps/multimap/end.mdx
+++ b/content/docs/std/containers/maps/multimap/end.mdx
@@ -4,13 +4,15 @@ sidebar_label:			end( )
 description:			multimap<...>::end() C++ documentation
 hide_title:				true
 tags:					[access, iterators, end, get]
+
+cppreference_origin_rel: w/cpp/container/multimap/end
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import Columns					from "@site-comps/Columns";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import TabItem					from "@theme/TabItem";
+import SwitchView			from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
+import TabItem				from "@theme/TabItem";
 
 <!-- Terms -->
 import Term_ContAlias_Iterator from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";
@@ -20,8 +22,8 @@ import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behav
 
 <!-- end -->
 
-import Method_UntilCpp11 	from './_codes/end/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/end/since-cpp11.mdx';
+import Method_UntilCpp11	from './_codes/end/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/end/since-cpp11.mdx';
 
 # std::multimap end() method
 

--- a/content/docs/std/containers/maps/multimap/equal_range.mdx
+++ b/content/docs/std/containers/maps/multimap/equal_range.mdx
@@ -4,10 +4,12 @@ sidebar_label:			equal_range( )
 description:			map<...>::equal_range() method C++ documentation
 hide_title:				true
 tags:					[map, equal_range, compare, equal, range]
+
+cppreference_origin_rel: w/cpp/container/multimap/equal_range
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/multimap/erase.mdx
+++ b/content/docs/std/containers/maps/multimap/erase.mdx
@@ -4,6 +4,8 @@ sidebar_label:			erase( )
 description:			map<...>::erase() method C++ documentation
 hide_title:				true
 tags:					[map, remove, erase, delete]
+
+cppreference_origin_rel: w/cpp/container/multimap/erase
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/maps/multimap/extract.mdx
+++ b/content/docs/std/containers/maps/multimap/extract.mdx
@@ -4,6 +4,8 @@ sidebar_label:			extract( )
 description:			map<...>::extract() method C++ documentation
 hide_title:				true
 tags:					[map, extract]
+
+cppreference_origin_rel: w/cpp/container/multimap/extract
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/maps/multimap/find.mdx
+++ b/content/docs/std/containers/maps/multimap/find.mdx
@@ -4,10 +4,12 @@ sidebar_label:			find( )
 description:			map<...>::find() method C++ documentation
 hide_title:				true
 tags:					[map, find, exists, contains, get]
+
+cppreference_origin_rel: w/cpp/container/multimap/find
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/multimap/get_allocator.mdx
+++ b/content/docs/std/containers/maps/multimap/get_allocator.mdx
@@ -4,6 +4,8 @@ sidebar_label:			get_allocator( )
 description:			map<...>::get_allocator() method C++ documentation
 hide_title:				true
 tags:					[allocator, get]
+
+cppreference_origin_rel: w/cpp/container/multimap/get_allocator
 ---
 
 import SwitchView				from "@site-comps/SwitchView";

--- a/content/docs/std/containers/maps/multimap/insert.mdx
+++ b/content/docs/std/containers/maps/multimap/insert.mdx
@@ -4,13 +4,15 @@ sidebar_label:			insert( )
 description:			multimap<...>::insert() method C++ documentation
 hide_title:				true
 tags:					[multimap, insert, add]
+
+cppreference_origin_rel: w/cpp/container/multimap/insert
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import ImproveSection			from "@site/i18n/en/presets/ImproveSection.mdx";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!-- Terms -->
 import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";

--- a/content/docs/std/containers/maps/multimap/key_comp.mdx
+++ b/content/docs/std/containers/maps/multimap/key_comp.mdx
@@ -4,6 +4,8 @@ sidebar_label:			key_comp( )
 description:			map<...>::key_comp() method C++ documentation
 hide_title:				true
 tags:					[compare, key_comp, key, comp]
+
+cppreference_origin_rel: w/cpp/container/multimap/key_comp
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/maps/multimap/lower_bound.mdx
+++ b/content/docs/std/containers/maps/multimap/lower_bound.mdx
@@ -4,10 +4,12 @@ sidebar_label:			lower_bound( )
 description:			map<...>::lower_bound() method C++ documentation
 hide_title:				true
 tags:					[map, lower_bound, less]
+
+cppreference_origin_rel: w/cpp/container/multimap/lower_bound
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/multimap/max_size.mdx
+++ b/content/docs/std/containers/maps/multimap/max_size.mdx
@@ -4,23 +4,25 @@ sidebar_label:			max_size( )
 description:			multimap<...>::max_size() method C++ documentation
 hide_title:				true
 tags:					[max, size, max_size]
+
+cppreference_origin_rel: w/cpp/container/multimap/max_size
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- max_size() -->
-import Method_UntilCpp11 	from './_codes/max_size/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/max_size/since-cpp11.mdx';
+import Method_UntilCpp11	from './_codes/max_size/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/max_size/since-cpp11.mdx';
 
 # std::multimap max_size() method
 
 <SwitchView content={{
-        'since-cpp11': <Method_SinceCpp11 />,
-        'until-cpp11': <Method_UntilCpp11 />,
-    }}/>
+		'since-cpp11': <Method_SinceCpp11 />,
+		'until-cpp11': <Method_UntilCpp11 />,
+	}}/>
 
 		
 Returns the **maximum number of elements** the container is able to hold due to system or library implementation limitations,

--- a/content/docs/std/containers/maps/multimap/merge.mdx
+++ b/content/docs/std/containers/maps/multimap/merge.mdx
@@ -4,6 +4,8 @@ sidebar_label:			merge( )
 description:			map<...>::merge() method C++ documentation
 hide_title:				true
 tags:					[map, merge, add, copy]
+
+cppreference_origin_rel: w/cpp/container/multimap/merge
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/maps/multimap/operator_assign.mdx
+++ b/content/docs/std/containers/maps/multimap/operator_assign.mdx
@@ -4,6 +4,8 @@ sidebar_label:			operator=
 description:			map<...>::operator= C++ documentation
 hide_title:				true
 tags:					[assign, replace, copy, set]
+
+cppreference_origin_rel: w/cpp/container/multimap/operator=
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/maps/multimap/rbegin.mdx
+++ b/content/docs/std/containers/maps/multimap/rbegin.mdx
@@ -4,6 +4,8 @@ sidebar_label:			rbegin( )
 description:		    multimap<...>::rbegin() method C++ documentation
 hide_title:				true
 tags:					[access, multimap, iterator, reverse, rbegin, begin]
+
+cppreference_origin_rel: w/cpp/container/multimap/rbegin
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/maps/multimap/rend.mdx
+++ b/content/docs/std/containers/maps/multimap/rend.mdx
@@ -4,6 +4,8 @@ sidebar_label:			rend( )
 description:			multimap<...>::rend() method C++ documentation
 hide_title:				true
 tags:					[access, map, rend, end]
+
+cppreference_origin_rel: w/cpp/container/multimap/rend
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/maps/multimap/size.mdx
+++ b/content/docs/std/containers/maps/multimap/size.mdx
@@ -4,6 +4,8 @@ sidebar_label:			size( )
 description:			multimap<...>::size() method C++ documentation
 hide_title:				true
 tags:					[size]
+
+cppreference_origin_rel: w/cpp/container/multimap/size
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/maps/multimap/swap.mdx
+++ b/content/docs/std/containers/maps/multimap/swap.mdx
@@ -4,6 +4,8 @@ sidebar_label:			swap( )
 description:			map<...>::swap() method C++ documentation
 hide_title:				true
 tags:					[map, swap]
+
+cppreference_origin_rel: w/cpp/container/multimap/swap
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/maps/multimap/upper_bound.mdx
+++ b/content/docs/std/containers/maps/multimap/upper_bound.mdx
@@ -4,10 +4,12 @@ sidebar_label:			upper_bound( )
 description:			map<...>::upper_bound() method C++ documentation
 hide_title:				true
 tags:					[map, upper_bound, more, greater]
+
+cppreference_origin_rel: w/cpp/container/multimap/upper_bound
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/multimap/value_comp.mdx
+++ b/content/docs/std/containers/maps/multimap/value_comp.mdx
@@ -4,6 +4,8 @@ sidebar_label:			value_comp( )
 description:			multimap<...>::value_comp() method C++ documentation
 hide_title:				true
 tags:					[compare, value_comp, value, comp]
+
+cppreference_origin_rel: w/cpp/container/multimap/value_comp
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/maps/multimap/value_compare.mdx
+++ b/content/docs/std/containers/maps/multimap/value_compare.mdx
@@ -4,6 +4,8 @@ sidebar_label:			value_compare
 description:			multimap<...>::value_compare member class C++ documentation
 hide_title:				true
 tags:					[compare, value_compare, class, value, comp]
+
+cppreference_origin_rel: w/cpp/container/multimap/value_compare
 ---
 
 

--- a/content/docs/std/containers/maps/unordered-map.mdx
+++ b/content/docs/std/containers/maps/unordered-map.mdx
@@ -5,10 +5,12 @@ sidebar_label:		unordered_map
 hide_title:			true
 description:		Summary of a std::unordered_map (usage, methods, etc.) - C++ Language
 tags:				[unordered_map, associative, container, multi, key, unordered]
+
+cppreference_origin_rel: w/cpp/container/unordered_map
 ---
 
 import ClassSummary				from "@site-comps/ClassSummary";
-import CustomCodeBlock				from "@site-comps/CustomCodeBlock";
+import CustomCodeBlock			from "@site-comps/CustomCodeBlock";
 import SymbolTable, { Symbol }	from "@site-comps/SymbolTable";
 import Columns					from "@site-comps/Columns";
 import NotFinished				from "@site/i18n/en/presets/NotFinished.mdx";

--- a/content/docs/std/containers/maps/unordered-map/at.mdx
+++ b/content/docs/std/containers/maps/unordered-map/at.mdx
@@ -4,10 +4,12 @@ sidebar_label:			at( )
 description:			unordered_map<...>::at() method C++ documentation
 hide_title:				true
 tags:					[at, access]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/at
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/unordered-map/begin.mdx
+++ b/content/docs/std/containers/maps/unordered-map/begin.mdx
@@ -4,13 +4,15 @@ sidebar_label:			begin( )
 description:			unordered_map<...>::begin() method C++ documentation
 hide_title:				true
 tags:					[access, unordered_map, iterator, begin, front]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/begin
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import TabItem					from "@theme/TabItem";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
+import TabItem				from "@theme/TabItem";
 
 <!-- Terms -->
 import Term_ContAlias_Iterator from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";

--- a/content/docs/std/containers/maps/unordered-map/begin_size_type.mdx
+++ b/content/docs/std/containers/maps/unordered-map/begin_size_type.mdx
@@ -4,10 +4,12 @@ sidebar_label:			begin( size_type )
 description:			unordered_map<...>::begin( size_type ) method C++ documentation
 hide_title:				true
 tags:					[iterator, access, bucket]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/begin2
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/unordered-map/bucket.mdx
+++ b/content/docs/std/containers/maps/unordered-map/bucket.mdx
@@ -4,10 +4,12 @@ sidebar_label:			bucket( )
 description:			unordered_map<...>::bucket() method C++ documentation
 hide_title:				true
 tags:					[bucket, index, count, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/bucket
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/unordered-map/bucket_count.mdx
+++ b/content/docs/std/containers/maps/unordered-map/bucket_count.mdx
@@ -4,6 +4,8 @@ sidebar_label:			bucket_count( )
 description:			unordered_map<...>::bucket_count() method C++ documentation
 hide_title:				true
 tags:					[bucket_count, bucket, count, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/bucket_count
 ---
 
 import SwitchView				from "@site-comps/SwitchView";

--- a/content/docs/std/containers/maps/unordered-map/bucket_size.mdx
+++ b/content/docs/std/containers/maps/unordered-map/bucket_size.mdx
@@ -4,10 +4,12 @@ sidebar_label:			bucket_size( )
 description:			unordered_map<...>::bucket_size() method C++ documentation
 hide_title:				true
 tags:					[bucket_size, bucket, count, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/bucket_size
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/unordered-map/clear.mdx
+++ b/content/docs/std/containers/maps/unordered-map/clear.mdx
@@ -4,10 +4,12 @@ sidebar_label:			clear()
 description:			unordered_map<...>::clear() method C++ documentation
 hide_title:				true
 tags:					[clear, remove, delete, unordered_map]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/clear
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/unordered-map/constructors.mdx
+++ b/content/docs/std/containers/maps/unordered-map/constructors.mdx
@@ -4,6 +4,8 @@ sidebar_label:			Constructors
 description:			unordered_map<...> constructors C++ documentation
 hide_title:				true
 tags:					[constructors, construct, create, unordered_map, new]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/unordered_map
 ---
 
 # std::unordered_map constructors

--- a/content/docs/std/containers/maps/unordered-map/contains.mdx
+++ b/content/docs/std/containers/maps/unordered-map/contains.mdx
@@ -4,10 +4,12 @@ sidebar_label:			contains()
 description:			unordered_map<...>::contains() method C++ documentation
 hide_title:				true
 tags:					[contains, existence, exists]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/contains
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/unordered-map/count.mdx
+++ b/content/docs/std/containers/maps/unordered-map/count.mdx
@@ -4,10 +4,12 @@ sidebar_label:			count()
 description:			unordered_map<...>::count() method C++ documentation
 hide_title:				true
 tags:					[count, contains, existence, exists]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/count
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/unordered-map/destructors.mdx
+++ b/content/docs/std/containers/maps/unordered-map/destructors.mdx
@@ -4,17 +4,19 @@ sidebar_label:		Destructor
 description:		unordered_map<...> destructor C++ documentation
 hide_title:			true
 tags:				[unordered_map, destruction, destructor]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/~unordered_map
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!-- destructors -->
-import Method_SinceCpp11 	from './_codes/destructors/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/destructors/since-cpp11.mdx';
 
 # std::unordered_map destructor
 
 <SwitchView content={{
-        'since-cpp11': <Method_SinceCpp11 />,
+	'since-cpp11': <Method_SinceCpp11 />,
 }} />
 
 Destructs the `unordered_map`.

--- a/content/docs/std/containers/maps/unordered-map/emplace.mdx
+++ b/content/docs/std/containers/maps/unordered-map/emplace.mdx
@@ -4,10 +4,12 @@ sidebar_label:			emplace()
 description:			unordered_map<...>::emplace() method C++ documentation
 hide_title:				true
 tags:					[emplace, add, emplace, append, unordered_map]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/emplace
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/unordered-map/emplace_hint.mdx
+++ b/content/docs/std/containers/maps/unordered-map/emplace_hint.mdx
@@ -4,11 +4,13 @@ sidebar_label:			emplace_hint()
 description:			unordered_map<...>::emplace_hint() method C++ documentation
 hide_title:				true
 tags:					[emplace_hint, add, emplace, append, unordered_map]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/emplace_hint
 ---
 
 import Columns				from "@site-comps/Columns";
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/unordered-map/empty.mdx
+++ b/content/docs/std/containers/maps/unordered-map/empty.mdx
@@ -4,10 +4,12 @@ sidebar_label:			empty()
 description:			unordered_map<...>::empty() method C++ documentation
 hide_title:				true
 tags:					[empty]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/empty
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/unordered-map/end.mdx
+++ b/content/docs/std/containers/maps/unordered-map/end.mdx
@@ -4,13 +4,15 @@ sidebar_label:			end( )
 description:			unordered_map<...>::end() method C++ documentation
 hide_title:				true
 tags:					[access, unordered_map, iterator, end, back]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/end
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import TabItem					from "@theme/TabItem";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
+import TabItem				from "@theme/TabItem";
 
 <!-- Terms -->
 import Term_ContAlias_Iterator from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";
@@ -19,13 +21,13 @@ import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behav
 <!----------------- Codes ---------------------->
 
 <!-- end() -->
-import Method_SinceCpp11 	from './_codes/end/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/end/since-cpp11.mdx';
 
 # std::unordered_map begin()/cbegin() method
 
 <SwitchView content={{
-        'since-cpp11': <Method_SinceCpp11 />,
-    }}/>
+	'since-cpp11': <Method_SinceCpp11 />,
+}}/>
 
 Returns an <Tooltip title={Term_ContAlias_Iterator}>iterator</Tooltip> to the element past-the-end of the unordered_map.
 If the unordered_map is empty, the returned iterator will be equal to [`begin()`](/docs/std/containers/maps/unordered-map/begin).

--- a/content/docs/std/containers/maps/unordered-map/end_size_type.mdx
+++ b/content/docs/std/containers/maps/unordered-map/end_size_type.mdx
@@ -4,21 +4,23 @@ sidebar_label:			end( size_type )
 description:			unordered_map<...>::end( size_type ) method C++ documentation
 hide_title:				true
 tags:					[iterator, access, bucket]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/end2
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
 
 <!----------------- Codes ---------------------->
 
 <!-- end( size_type ) -->
-import Method_SinceCpp11 	from './_codes/end_size_type/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/end_size_type/since-cpp11.mdx';
 
 # std::unordered_map end( size_type ) method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns an iterator to the element following the last element of the bucket with index `n`.
 

--- a/content/docs/std/containers/maps/unordered-map/equal_range.mdx
+++ b/content/docs/std/containers/maps/unordered-map/equal_range.mdx
@@ -4,23 +4,25 @@ sidebar_label:			equal_range()
 description:			unordered_map<...>::equal_range() method C++ documentation
 hide_title:				true
 tags:					[equal_range, equal, range]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/equal_range
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- equal_range() -->
-import Method_SinceCpp11 	from './_codes/equal_range/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/equal_range/since-cpp20.mdx';
+import Method_SinceCpp11	from './_codes/equal_range/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/equal_range/since-cpp20.mdx';
 
 # std::unordered_map equal_range() method
 
 <SwitchView content={{
-    'since-cpp20': <Method_SinceCpp20 />,
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
  - **(1-2)** Returns a range containing all elements with key `key` in the container.
     The range is defined by two iterators, the first pointing to the first element of the wanted range and the second pointing past the last element of the range.

--- a/content/docs/std/containers/maps/unordered-map/erase.mdx
+++ b/content/docs/std/containers/maps/unordered-map/erase.mdx
@@ -4,23 +4,25 @@ sidebar_label:			erase()
 description:			unordered_map<...>::erase() method C++ documentation
 hide_title:				true
 tags:					[erase, remove, delete, unordered_map]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/erase
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- erase() -->
-import Method_SinceCpp11 	from './_codes/erase/since-cpp11.mdx';
-import Method_SinceCpp23 	from './_codes/erase/since-cpp23.mdx';
+import Method_SinceCpp11	from './_codes/erase/since-cpp11.mdx';
+import Method_SinceCpp23	from './_codes/erase/since-cpp23.mdx';
 
 # std::unordered_map erase() method
 
 <SwitchView content={{
-    'since-cpp23': <Method_SinceCpp23 />,
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp23': <Method_SinceCpp23 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
  - **(1)** Removes the element at `pos`.
  - **(2)** Removes the elements in the range **[ first; last )**, which must be a valid range in `*this`.

--- a/content/docs/std/containers/maps/unordered-map/extract.mdx
+++ b/content/docs/std/containers/maps/unordered-map/extract.mdx
@@ -4,22 +4,24 @@ sidebar_label:			extract()
 description:			unordered_map<...>::extract() method C++ documentation
 hide_title:				true
 tags:					[extract, unordered_map]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/extract
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp17 	from './_codes/extract/since-cpp17.mdx';
-import Method_SinceCpp23 	from './_codes/extract/since-cpp23.mdx';
+import Method_SinceCpp17	from './_codes/extract/since-cpp17.mdx';
+import Method_SinceCpp23	from './_codes/extract/since-cpp23.mdx';
 
 # std::unordered_map extract() method
 
 <SwitchView content={{
-    'since-cpp23': <Method_SinceCpp23 />,
-    'since-cpp17': <Method_SinceCpp17 />,
-    }} />
+	'since-cpp23': <Method_SinceCpp23 />,
+	'since-cpp17': <Method_SinceCpp17 />,
+}} />
 
  - **(1)**
     Unlinks the node that contains the element pointed to by position and returns a node handle that owns it.

--- a/content/docs/std/containers/maps/unordered-map/find.mdx
+++ b/content/docs/std/containers/maps/unordered-map/find.mdx
@@ -4,10 +4,12 @@ sidebar_label:			find()
 description:			unordered_map<...>::find() method C++ documentation
 hide_title:				true
 tags:					[find, existence, exists]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/find
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/unordered-map/get_allocator.mdx
+++ b/content/docs/std/containers/maps/unordered-map/get_allocator.mdx
@@ -4,20 +4,22 @@ sidebar_label:			get_allocator
 description:			unordered_map<...>::get_allocator method C++ documentation
 hide_title:				true
 tags:					[unordered_map, allocator, get_allocator]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/get_allocator
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
 
 <!----------------- Codes ---------------------->
 
 <!-- get_allocator() -->
-import Method_SinceCpp11 	from './_codes/get_allocator/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/get_allocator/since-cpp11.mdx';
 
 # std::unordered_map get_allocator() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
+	'since-cpp11': <Method_SinceCpp11 />,
 }} />
 
 Returns the allocator associated with the container.

--- a/content/docs/std/containers/maps/unordered-map/hash_function.mdx
+++ b/content/docs/std/containers/maps/unordered-map/hash_function.mdx
@@ -4,10 +4,12 @@ sidebar_label:			hash_function( )
 description:			unordered_map<...>::hash_function() method C++ documentation
 hide_title:				true
 tags:					[compare, hash_function, hash, function, hasher]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/hash_function
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/unordered-map/insert.mdx
+++ b/content/docs/std/containers/maps/unordered-map/insert.mdx
@@ -4,17 +4,19 @@ sidebar_label:			insert()
 description:			unordered_map<...>::insert() method C++ documentation
 hide_title:				true
 tags:					[insert, add, append, unordered_map]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/insert
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
 
 <!----------------- Codes ---------------------->
 
 <!-- insert() -->
-import Method_SinceCpp17 	from './_codes/insert/since-cpp17.mdx';
-import Method_UntilCpp17 	from './_codes/insert/until-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/insert/since-cpp17.mdx';
+import Method_UntilCpp17	from './_codes/insert/until-cpp17.mdx';
 
 import IteratorDereferenceNote_UntilCpp17 	from './_codes/insert/explanation/iterator-dereference-note-until-cpp17.mdx';
 import IteratorDereferenceNote_SinceCpp17 	from './_codes/insert/explanation/iterator-dereference-note-since-cpp17.mdx';
@@ -22,9 +24,9 @@ import IteratorDereferenceNote_SinceCpp17 	from './_codes/insert/explanation/ite
 # std::unordered_map insert() method
 
 <SwitchView content={{
-    'since-cpp17': <Method_SinceCpp17 />,
-    'until-cpp17': <Method_UntilCpp17 />
-    }} />
+	'since-cpp17': <Method_SinceCpp17 />,
+	'until-cpp17': <Method_UntilCpp17 />
+}} />
 
 Inserts element(s) into the container, if the container doesn't already contain an element with an equivalent key.
 

--- a/content/docs/std/containers/maps/unordered-map/insert_or_assign.mdx
+++ b/content/docs/std/containers/maps/unordered-map/insert_or_assign.mdx
@@ -4,21 +4,23 @@ sidebar_label:			insert_or_assign()
 description:			unordered_map<...>::insert_or_assign() method C++ documentation
 hide_title:				true
 tags:					[insert_or_assign, add, append, insert, assign, unordered_map]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/insert_or_assign
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- insert_or_assign() -->
-import Method_SinceCpp17 	from './_codes/insert_or_assign/since-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/insert_or_assign/since-cpp17.mdx';
 
 # std::unordered_map insert_or_assign() method
 
 <SwitchView content={{
-    'since-cpp17': <Method_SinceCpp17 />,
-    }} />
+	'since-cpp17': <Method_SinceCpp17 />,
+}} />
 
  - **(1-3)** 
     If a key equivalent to `k` already exists in the container, assigns `std::forward<M>(obj)` to the `mapped_type` corresponding to the key `k`.

--- a/content/docs/std/containers/maps/unordered-map/key_eq.mdx
+++ b/content/docs/std/containers/maps/unordered-map/key_eq.mdx
@@ -4,21 +4,23 @@ sidebar_label:			key_eq( )
 description:			unordered_map<...>::key_eq() method C++ documentation
 hide_title:				true
 tags:					[compare, key_eq, hash, function, hasher]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/key_eq
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
 
 <!----------------- Codes ---------------------->
 
 <!-- key_eq() -->
-import Method_SinceCpp11 	from './_codes/key_eq/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/key_eq/since-cpp11.mdx';
 
 # std::unordered_map key_eq() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the function that compares keys for equality.
 

--- a/content/docs/std/containers/maps/unordered-map/load_factor.mdx
+++ b/content/docs/std/containers/maps/unordered-map/load_factor.mdx
@@ -4,10 +4,12 @@ sidebar_label:			load_factor( )
 description:			unordered_map<...>::load_factor() method C++ documentation
 hide_title:				true
 tags:					[load_factor, factor, elements, bucket, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/load_factor
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/unordered-map/max_bucket_count.mdx
+++ b/content/docs/std/containers/maps/unordered-map/max_bucket_count.mdx
@@ -4,21 +4,23 @@ sidebar_label:			max_bucket_count( )
 description:			unordered_map<...>::max_bucket_count() method C++ documentation
 hide_title:				true
 tags:					[max_bucket_count, bucket, count, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/max_bucket_count
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- max_bucket_count() -->
-import Method_SinceCpp11 	from './_codes/max_bucket_count/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/max_bucket_count/since-cpp11.mdx';
 
 # std::unordered_map max_bucket_count() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the maximum number of buckets the container is able to hold due to system or library implementation limitations.
 

--- a/content/docs/std/containers/maps/unordered-map/max_load_factor.mdx
+++ b/content/docs/std/containers/maps/unordered-map/max_load_factor.mdx
@@ -4,21 +4,23 @@ sidebar_label:			max_load_factor( )
 description:			unordered_map<...>::max_load_factor() method C++ documentation
 hide_title:				true
 tags:					[max_load_factor, factor, elements, bucket, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/max_load_factor
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
 
 <!----------------- Codes ---------------------->
 
 <!-- max_load_factor() -->
-import Method_SinceCpp11 	from './_codes/max_load_factor/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/max_load_factor/since-cpp11.mdx';
 
 # std::unordered_map max_load_factor() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Manages the maximum load factor (number of elements per bucket).
 The container automatically increases the number of buckets if the load factor exceeds this threshold.

--- a/content/docs/std/containers/maps/unordered-map/max_size.mdx
+++ b/content/docs/std/containers/maps/unordered-map/max_size.mdx
@@ -4,10 +4,12 @@ sidebar_label:			max_size()
 description:			unordered_map<...>::max_size() method C++ documentation
 hide_title:				true
 tags:					[max_size, size, elements, amount]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/max_size
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
@@ -17,8 +19,8 @@ import Method_SinceCpp11 	from './_codes/max_size/since-cpp11.mdx';
 # std::unordered_map max_size() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the maximum number of elements the container is able to hold due to system or library implementation limitations, i.e. `std::distance(begin(), end())` for the largest container.
 

--- a/content/docs/std/containers/maps/unordered-map/merge.mdx
+++ b/content/docs/std/containers/maps/unordered-map/merge.mdx
@@ -4,10 +4,12 @@ sidebar_label:			merge()
 description:			unordered_map<...>::merge() method C++ documentation
 hide_title:				true
 tags:					[merge, copy, connect, unordered_map]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/merge
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
@@ -16,8 +18,8 @@ import Method_SinceCpp17 	from './_codes/merge/since-cpp17.mdx';
 # std::unordered_map merge() method
 
 <SwitchView content={{
-    'since-cpp17': <Method_SinceCpp17 />,
-    }} />
+	'since-cpp17': <Method_SinceCpp17 />,
+}} />
 
 Attempts to extract ("splice") each element in source and insert it into `*this` using the hash function and key equality predicate of `*this`.
 

--- a/content/docs/std/containers/maps/unordered-map/operator_assign.mdx
+++ b/content/docs/std/containers/maps/unordered-map/operator_assign.mdx
@@ -4,24 +4,26 @@ sidebar_label:			operator=
 description:			unordered_map<...>::operator= method C++ documentation
 hide_title:				true
 tags:					[unordered_map, assign, copy, operator_assign]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/operator=
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- operator_assign() -->
-import Method_UntilCpp17 	from './_codes/operator_assign/until-cpp17.mdx';
-import Method_SinceCpp17 	from './_codes/operator_assign/since-cpp17.mdx';
+import Method_UntilCpp17	from './_codes/operator_assign/until-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/operator_assign/since-cpp17.mdx';
 
 import NoexceptSpecification_SinceCpp17  from './_codes/operator_assign/noexcept-specification/since-cpp17.mdx';
 
 # std::unordered_map operator=
 
 <SwitchView content={{
-    'since-cpp17': <Method_SinceCpp17 />,
-    'until-cpp17': <Method_UntilCpp17 />
+	'since-cpp17': <Method_SinceCpp17 />,
+	'until-cpp17': <Method_UntilCpp17 />
 }} />
 
 Replaces the contents of the container with the contents of another.

--- a/content/docs/std/containers/maps/unordered-map/operator_subscript.mdx
+++ b/content/docs/std/containers/maps/unordered-map/operator_subscript.mdx
@@ -4,33 +4,35 @@ sidebar_label:			operator[]
 description:			unordered_map<...>::operator[] method C++ documentation
 hide_title:				true
 tags:					[operator, subscript, index, indexing, access]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/operator_at
 ---
 
-import Columns				from "@site-comps/Columns";
+import Columns					from "@site-comps/Columns";
 import SwitchView				from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- operator[] -->
-import Explanation_UntilCpp17   from './_codes/operator_subscript/explanation/until-cpp17.mdx';
-import Explanation_SinceCpp17   from './_codes/operator_subscript/explanation/since-cpp17.mdx';
+import Explanation_UntilCpp17		from './_codes/operator_subscript/explanation/until-cpp17.mdx';
+import Explanation_SinceCpp17		from './_codes/operator_subscript/explanation/since-cpp17.mdx';
 
-import Notes_InsertOrAssign_Since17 from './_codes/operator_subscript/other/notes-insert-or-assign-since-cpp17.mdx';
+import Notes_InsertOrAssign_Since17	from './_codes/operator_subscript/other/notes-insert-or-assign-since-cpp17.mdx';
 
-import Method_SinceCpp11 	from './_codes/operator_subscript/since-cpp11.mdx';
+import Method_SinceCpp11			from './_codes/operator_subscript/since-cpp11.mdx';
 
 # std::unordered_map operator[] method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns a reference to the value that is mapped to a key equivalent to `key`, performing an insertion if such key does not already exist.
 
 <SwitchView content={{
-    'since-cpp17': <Explanation_SinceCpp17 />,
-    'until-cpp17': <Explanation_UntilCpp17 />,
-    }} />
+	'since-cpp17': <Explanation_SinceCpp17 />,
+	'until-cpp17': <Explanation_UntilCpp17 />,
+}} />
 
 :::danger Invalidation
 If an insertion occurs and results in a rehashing of the container, **all iterators** are invalidated.

--- a/content/docs/std/containers/maps/unordered-map/rehash.mdx
+++ b/content/docs/std/containers/maps/unordered-map/rehash.mdx
@@ -4,21 +4,23 @@ sidebar_label:			rehash( )
 description:			unordered_map<...>::rehash() method C++ documentation
 hide_title:				true
 tags:					[rehash, hash, buckets, bucket]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/rehash
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
 
 <!----------------- Codes ---------------------->
 
 <!-- rehash() -->
-import Method_SinceCpp11 	from './_codes/rehash/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/rehash/since-cpp11.mdx';
 
 # std::unordered_map rehash() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 		
 Sets the number of buckets to `count` and rehashes the container, i.e. puts the elements into appropriate buckets considering that total number of buckets has changed.

--- a/content/docs/std/containers/maps/unordered-map/reserve.mdx
+++ b/content/docs/std/containers/maps/unordered-map/reserve.mdx
@@ -4,21 +4,23 @@ sidebar_label:			reserve( )
 description:			unordered_map<...>::reserve() method C++ documentation
 hide_title:				true
 tags:					[reserve, buckets, bucket]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/reserve
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
 
 <!----------------- Codes ---------------------->
 
 <!-- reserve() -->
-import Method_SinceCpp11 	from './_codes/reserve/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/reserve/since-cpp11.mdx';
 
 # std::unordered_map reserve() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Sets the number of buckets to the number needed to accomodate at least `count` elements without exceeding maximum load factor and **rehashes the container**,
 i.e. puts the elements into appropriate buckets considering that total number of buckets has changed.

--- a/content/docs/std/containers/maps/unordered-map/size.mdx
+++ b/content/docs/std/containers/maps/unordered-map/size.mdx
@@ -4,10 +4,12 @@ sidebar_label:			size()
 description:			unordered_map<...>::size() method C++ documentation
 hide_title:				true
 tags:					[size, elements, number, amount]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/size
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
@@ -17,8 +19,8 @@ import Method_SinceCpp11 	from './_codes/size/since-cpp11.mdx';
 # std::unordered_map size() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the number of elements in the container, i.e. `std::distance(begin(), end())`.
 

--- a/content/docs/std/containers/maps/unordered-map/swap.mdx
+++ b/content/docs/std/containers/maps/unordered-map/swap.mdx
@@ -4,16 +4,18 @@ sidebar_label:			swap()
 description:			unordered_map<...>::swap() method C++ documentation
 hide_title:				true
 tags:					[swap, exchange, unordered_map]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/swap
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- swap() -->
-import Method_SinceCpp17 	from './_codes/swap/since-cpp17.mdx';
-import Method_UntilCpp17 	from './_codes/swap/until-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/swap/since-cpp17.mdx';
+import Method_UntilCpp17	from './_codes/swap/until-cpp17.mdx';
 
 
 import NoexceptSpecification_SinceCpp17 from './_codes/swap/noexcept-specification/since-cpp17.mdx';
@@ -22,9 +24,9 @@ import PropagateOnContainerChangeNote_SinceCpp11 from './_codes/swap/explanation
 # std::unordered_map swap() method
 
 <SwitchView content={{
-    'since-cpp17': <Method_SinceCpp17 />,
-    'until-cpp17': <Method_UntilCpp17 />
-    }} />
+	'since-cpp17': <Method_SinceCpp17 />,
+	'until-cpp17': <Method_UntilCpp17 />
+}} />
 
 Exchanges the contents of the container with those of `other`. Does not invoke any move, copy, or swap operations on individual elements.
 

--- a/content/docs/std/containers/maps/unordered-map/try_emplace.mdx
+++ b/content/docs/std/containers/maps/unordered-map/try_emplace.mdx
@@ -4,15 +4,17 @@ sidebar_label:			try_emplace()
 description:			unordered_map<...>::try_emplace() method C++ documentation
 hide_title:				true
 tags:					[try_emplace, add, emplace, append, unordered_map]
+
+cppreference_origin_rel: w/cpp/container/unordered_map/try_emplace
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- try_emplace() -->
-import Method_SinceCpp17 	from './_codes/try_emplace/since-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/try_emplace/since-cpp17.mdx';
 
 
 # std::unordered_map try_emplace() method

--- a/content/docs/std/containers/maps/unordered-multimap.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap.mdx
@@ -5,10 +5,12 @@ sidebar_label:		unordered_multimap
 hide_title:			true
 description:		Summary of a std::unordered_multimap (usage, methods, etc.) - C++ Language
 tags:				[unordered_multimap, container, associative, key, multi, unordered]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap
 ---
 
 import ClassSummary				from "@site-comps/ClassSummary";
-import CustomCodeBlock				from "@site-comps/CustomCodeBlock";
+import CustomCodeBlock			from "@site-comps/CustomCodeBlock";
 import SymbolTable, { Symbol }	from "@site-comps/SymbolTable";
 import Columns					from "@site-comps/Columns";
 import NotFinished				from "@site/i18n/en/presets/NotFinished.mdx";

--- a/content/docs/std/containers/maps/unordered-multimap/begin.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/begin.mdx
@@ -4,27 +4,29 @@ sidebar_label:			begin( )
 description:			unordered_multimap<...>::begin() method C++ documentation
 hide_title:				true
 tags:					[access, unordered_multimap, iterator, begin, front]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/begin
 ---
 
 import Columns					from "@site-comps/Columns";
 import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Tooltip					from "@site-comps/Tooltip";
+import Tabs						from "@theme/Tabs";
 import TabItem					from "@theme/TabItem";
 
 <!-- Terms -->
-import Term_ContAlias_Iterator from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";
+import Term_ContAlias_Iterator	from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- begin() -->
-import Method_SinceCpp11 	from './_codes/begin/since-cpp11.mdx';
+import Method_SinceCpp11		from './_codes/begin/since-cpp11.mdx';
 
 # std::unordered_multimap begin()/cbegin() method
 
 <SwitchView content={{
-        'since-cpp11': <Method_SinceCpp11 />,
-    }}/>
+	'since-cpp11': <Method_SinceCpp11 />,
+}}/>
 
 Returns an <Tooltip title={Term_ContAlias_Iterator}>iterator</Tooltip> to the first element of the vector.
 If the array is empty, the returned iterator will be equal to [`end()`](/docs/std/containers/maps/unordered-multimap/end).

--- a/content/docs/std/containers/maps/unordered-multimap/begin_size_type.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/begin_size_type.mdx
@@ -4,21 +4,23 @@ sidebar_label:			begin( size_type )
 description:			unordered_multimap<...>::begin( size_type ) method C++ documentation
 hide_title:				true
 tags:					[iterator, access, bucket]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/begin2
 ---
 
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- begin( size_type ) -->
-import Method_SinceCpp11 	from './_codes/begin_size_type/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/begin_size_type/since-cpp11.mdx';
 
 # std::unordered_multimap begin( size_type ) method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns an iterator to the first element of the bucket with index `n`.
 

--- a/content/docs/std/containers/maps/unordered-multimap/bucket.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/bucket.mdx
@@ -4,6 +4,8 @@ sidebar_label:			bucket( )
 description:			unordered_multimap<...>::bucket() method C++ documentation
 hide_title:				true
 tags:					[bucket, index, count, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/bucket
 ---
 
 import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";

--- a/content/docs/std/containers/maps/unordered-multimap/bucket_count.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/bucket_count.mdx
@@ -4,21 +4,23 @@ sidebar_label:			bucket_count( )
 description:			unordered_multimap<...>::bucket_count() method C++ documentation
 hide_title:				true
 tags:					[bucket_count, bucket, count, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/bucket_count
 ---
 
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- bucket_count() -->
-import Method_SinceCpp11 	from './_codes/bucket_count/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/bucket_count/since-cpp11.mdx';
 
 # std::unordered_multimap bucket_count() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the number of buckets in the container.
 

--- a/content/docs/std/containers/maps/unordered-multimap/bucket_size.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/bucket_size.mdx
@@ -4,21 +4,23 @@ sidebar_label:			bucket_size( )
 description:			unordered_multimap<...>::bucket_size() method C++ documentation
 hide_title:				true
 tags:					[bucket_size, bucket, count, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/bucket_size
 ---
 
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- bucket_size() -->
-import Method_SinceCpp11 	from './_codes/bucket_size/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/bucket_size/since-cpp11.mdx';
 
 # std::unordered_multimap bucket_size() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the number of elements in the bucket with index `n`.
 

--- a/content/docs/std/containers/maps/unordered-multimap/clear.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/clear.mdx
@@ -4,6 +4,8 @@ sidebar_label:			clear( )
 description:			unordered_multimap<...>::clear() method C++ documentation
 hide_title:				true
 tags:					[clear, remove, delete, unordered_multimap]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/clear
 ---
 
 import Columns				from "@site-comps/Columns";

--- a/content/docs/std/containers/maps/unordered-multimap/constructors.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/constructors.mdx
@@ -4,6 +4,8 @@ sidebar_label:			Constructors
 description:			unordered_multimap<...> constructors C++ documentation
 hide_title:				true
 tags:					[constructors, construct, create, unordered_multimap, new]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/unordered_multimap
 ---
 
 # std::unordered_multimap constructors

--- a/content/docs/std/containers/maps/unordered-multimap/contains.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/contains.mdx
@@ -4,21 +4,23 @@ sidebar_label:			contains( )
 description:			unordered_multimap<...>::contains() method C++ documentation
 hide_title:				true
 tags:					[contains, existence, exists]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/contains
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- contains() -->
-import Method_SinceCpp20 	from './_codes/contains/since-cpp20.mdx';
+import Method_SinceCpp20	from './_codes/contains/since-cpp20.mdx';
 
 # std::unordered_multimap contains() method
 
 <SwitchView content={{
-    'since-cpp20': <Method_SinceCpp20 />,
-    }} />
+	'since-cpp20': <Method_SinceCpp20 />,
+}} />
 
  - **(1)** Checks if there is an element with key equivalent to `key` in the container.
  - **(2)** Checks if there is an element with key that compares equivalent to the value `x`.

--- a/content/docs/std/containers/maps/unordered-multimap/count.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/count.mdx
@@ -4,10 +4,12 @@ sidebar_label:			count( )
 description:			unordered_multimap<...>::count() method C++ documentation
 hide_title:				true
 tags:					[count, contains, existence, exists]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/count
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/maps/unordered-multimap/destructors.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/destructors.mdx
@@ -4,17 +4,19 @@ sidebar_label:		Destructor
 description:		unordered_multimap<...> destructor C++ documentation
 hide_title:			true
 tags:				[unordered_multimap, destruction, destructor]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/~unordered_multimap
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!-- destructors -->
-import Method_SinceCpp11 	from './_codes/destructors/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/destructors/since-cpp11.mdx';
 
 # std::unordered_multimap destructors
 
 <SwitchView content={{
-        'since-cpp11': <Method_SinceCpp11 />,
+	'since-cpp11': <Method_SinceCpp11 />,
 }} />
 
 Destructs the `unordered_multimap`.

--- a/content/docs/std/containers/maps/unordered-multimap/emplace.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/emplace.mdx
@@ -4,10 +4,12 @@ sidebar_label:			emplace( )
 description:			unordered_multimap<...>::emplace() method C++ documentation
 hide_title:				true
 tags:					[emplace, add, emplace, append, unordered_multimap]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/emplace
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
@@ -17,8 +19,8 @@ import Method_SinceCpp11 	from './_codes/emplace/since-cpp11.mdx';
 # std::unordered_multimap emplace() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Inserts a new element into the container constructed in-place with the given `args` if there is no element with the key in the container.
 

--- a/content/docs/std/containers/maps/unordered-multimap/emplace_hint.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/emplace_hint.mdx
@@ -4,22 +4,24 @@ sidebar_label:			emplace_hint( )
 description:			unordered_multimap<...>::emplace_hint() method C++ documentation
 hide_title:				true
 tags:					[emplace_hint, add, emplace, append, unordered_multimap]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/emplace_hint
 ---
 
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- emplace_hint() -->
-import Method_SinceCpp11 	from './_codes/emplace_hint/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/emplace_hint/since-cpp11.mdx';
 
 # std::unordered_multimap emplace_hint() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Inserts a new element to the container, using hint as a suggestion where the element should go. The element is constructed in-place, i.e. no copy or move operations are performed.
 

--- a/content/docs/std/containers/maps/unordered-multimap/empty.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/empty.mdx
@@ -4,23 +4,25 @@ sidebar_label:			empty( )
 description:			unordered_multimap<...>::empty() method C++ documentation
 hide_title:				true
 tags:					[empty]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/empty
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- empty() -->
-import Method_UntilCpp20 	from './_codes/empty/until-cpp20.mdx';
-import Method_SinceCpp20 	from './_codes/empty/since-cpp20.mdx';
+import Method_UntilCpp20	from './_codes/empty/until-cpp20.mdx';
+import Method_SinceCpp20	from './_codes/empty/since-cpp20.mdx';
 
 # std::unordered_multimap empty() method
 
 <SwitchView content={{
-        'since-cpp20': <Method_SinceCpp20 />,
-        'until-cpp20': <Method_UntilCpp20 />,
-    }} />
+	'since-cpp20': <Method_SinceCpp20 />,
+	'until-cpp20': <Method_UntilCpp20 />,
+}} />
 
 Checks if the container has no elements, i.e. whether `begin() == end()`.
 

--- a/content/docs/std/containers/maps/unordered-multimap/end.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/end.mdx
@@ -4,28 +4,30 @@ sidebar_label:			end( )
 description:			unordered_multimap<...>::end() method C++ documentation
 hide_title:				true
 tags:					[access, unordered_multimap, iterator, end, back]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/end
 ---
 
 import Columns					from "@site-comps/Columns";
 import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Tooltip					from "@site-comps/Tooltip";
+import Tabs						from "@theme/Tabs";
 import TabItem					from "@theme/TabItem";
 
 <!-- Terms -->
-import Term_ContAlias_Iterator from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";
-import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
+import Term_ContAlias_Iterator	from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";
+import Term_UndefinedBehaviour	from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- end() -->
-import Method_SinceCpp11 	from './_codes/end/since-cpp11.mdx';
+import Method_SinceCpp11		from './_codes/end/since-cpp11.mdx';
 
 # std::unordered_multimap begin()/cbegin() method
 
 <SwitchView content={{
-        'since-cpp11': <Method_SinceCpp11 />,
-    }}/>
+		'since-cpp11': <Method_SinceCpp11 />,
+	}}/>
 
 Returns an <Tooltip title={Term_ContAlias_Iterator}>iterator</Tooltip> to the element past-the-end of the unordered_multimap.
 If the unordered_multimap is empty, the returned iterator will be equal to [`begin()`](/docs/std/containers/maps/unordered-multimap/begin).

--- a/content/docs/std/containers/maps/unordered-multimap/end_size_type.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/end_size_type.mdx
@@ -4,21 +4,23 @@ sidebar_label:			end( size_type )
 description:			unordered_multimap<...>::end( size_type ) method C++ documentation
 hide_title:				true
 tags:					[iterator, access, bucket]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/end2
 ---
 
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- end( size_type ) -->
-import Method_SinceCpp11 	from './_codes/end_size_type/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/end_size_type/since-cpp11.mdx';
 
 # std::unordered_multimap end( size_type ) method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns an iterator to the element following the last element of the bucket with index `n`.
 

--- a/content/docs/std/containers/maps/unordered-multimap/equal_range.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/equal_range.mdx
@@ -4,23 +4,25 @@ sidebar_label:			equal_range( )
 description:			unordered_multimap<...>::equal_range() method C++ documentation
 hide_title:				true
 tags:					[equal_range, equal, range]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/equal_range
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- equal_range() -->
-import Method_SinceCpp11 	from './_codes/equal_range/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/equal_range/since-cpp20.mdx';
+import Method_SinceCpp11	from './_codes/equal_range/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/equal_range/since-cpp20.mdx';
 
 # std::unordered_multimap equal_range() method
 
 <SwitchView content={{
-    'since-cpp20': <Method_SinceCpp20 />,
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
  - **(1-2)** Returns a range containing all elements with key `key` in the container.
     The range is defined by two iterators, the first pointing to the first element of the wanted range and the second pointing past the last element of the range.

--- a/content/docs/std/containers/maps/unordered-multimap/erase.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/erase.mdx
@@ -4,23 +4,25 @@ sidebar_label:			erase( )
 description:			unordered_multimap<...>::erase() method C++ documentation
 hide_title:				true
 tags:					[erase, remove, delete, unordered_multimap]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/erase
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- erase() -->
-import Method_SinceCpp11 	from './_codes/erase/since-cpp11.mdx';
-import Method_SinceCpp23 	from './_codes/erase/since-cpp23.mdx';
+import Method_SinceCpp11	from './_codes/erase/since-cpp11.mdx';
+import Method_SinceCpp23	from './_codes/erase/since-cpp23.mdx';
 
 # std::unordered_multimap erase() method
 
 <SwitchView content={{
-    'since-cpp23': <Method_SinceCpp23 />,
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp23': <Method_SinceCpp23 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
  - **(1)** Removes the element at `pos`.
  - **(2)** Removes the elements in the range **[ first; last )**, which must be a valid range in `*this`.

--- a/content/docs/std/containers/maps/unordered-multimap/extract.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/extract.mdx
@@ -4,22 +4,24 @@ sidebar_label:			extract( )
 description:			unordered_multimap<...>::extract() method C++ documentation
 hide_title:				true
 tags:					[extract, unordered_multimap]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/extract
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp17 	from './_codes/extract/since-cpp17.mdx';
-import Method_SinceCpp23 	from './_codes/extract/since-cpp23.mdx';
+import Method_SinceCpp17	from './_codes/extract/since-cpp17.mdx';
+import Method_SinceCpp23	from './_codes/extract/since-cpp23.mdx';
 
 # std::unordered_multimap extract() method
 
 <SwitchView content={{
-    'since-cpp23': <Method_SinceCpp23 />,
-    'since-cpp17': <Method_SinceCpp17 />,
-    }} />
+	'since-cpp23': <Method_SinceCpp23 />,
+	'since-cpp17': <Method_SinceCpp17 />,
+}} />
 
  - **(1)**
     Unlinks the node that contains the element pointed to by position and returns a node handle that owns it.

--- a/content/docs/std/containers/maps/unordered-multimap/find.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/find.mdx
@@ -4,10 +4,12 @@ sidebar_label:			find( )
 description:			unordered_multimap<...>::find() method C++ documentation
 hide_title:				true
 tags:					[find, existence, exists]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/find
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
@@ -18,9 +20,9 @@ import Method_SinceCpp20 	from './_codes/find/since-cpp20.mdx';
 # std::unordered_multimap find() method
 
 <SwitchView content={{
-    'since-cpp20': <Method_SinceCpp20 />,
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
  - **(1-2)** Finds an element with key equivalent to `key`.
  - **(3-4)** Finds an element with key that compares equivalent to the value `x`.

--- a/content/docs/std/containers/maps/unordered-multimap/get_allocator.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/get_allocator.mdx
@@ -4,10 +4,12 @@ sidebar_label:			get_allocator( )
 description:			unordered_multimap<...>::get_allocator method C++ documentation
 hide_title:				true
 tags:					[unordered_multimap, allocator, get_allocator]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/get_allocator
 ---
 
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
@@ -17,7 +19,7 @@ import Method_SinceCpp11 	from './_codes/get_allocator/since-cpp11.mdx';
 # std::unordered_multimap get_allocator() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
+	'since-cpp11': <Method_SinceCpp11 />,
 }} />
 
 Returns the allocator associated with the container.

--- a/content/docs/std/containers/maps/unordered-multimap/hash_function.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/hash_function.mdx
@@ -4,21 +4,23 @@ sidebar_label:			hash_function( )
 description:			unordered_multimap<...>::hash_function() method C++ documentation
 hide_title:				true
 tags:					[compare, hash_function, hash, function, hasher]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/hash_function
 ---
 
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- hash_function() -->
-import Method_SinceCpp11 	from './_codes/hash_function/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/hash_function/since-cpp11.mdx';
 
 # std::unordered_multimap hash_function() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the function that hashes the keys.
 

--- a/content/docs/std/containers/maps/unordered-multimap/insert.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/insert.mdx
@@ -4,16 +4,18 @@ sidebar_label:			insert( )
 description:			unordered_multimap<...>::insert() method C++ documentation
 hide_title:				true
 tags:					[insert, add, append, unordered_multimap]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/insert
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- insert() -->
-import Method_SinceCpp17 	from './_codes/insert/since-cpp17.mdx';
-import Method_UntilCpp17 	from './_codes/insert/until-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/insert/since-cpp17.mdx';
+import Method_UntilCpp17	from './_codes/insert/until-cpp17.mdx';
 
 import IteratorDereferenceNote_UntilCpp17 	from './_codes/insert/explanation/iterator-dereference-note-until-cpp17.mdx';
 import IteratorDereferenceNote_SinceCpp17 	from './_codes/insert/explanation/iterator-dereference-note-since-cpp17.mdx';
@@ -21,9 +23,9 @@ import IteratorDereferenceNote_SinceCpp17 	from './_codes/insert/explanation/ite
 # std::unordered_multimap insert() method
 
 <SwitchView content={{
-    'since-cpp17': <Method_SinceCpp17 />,
-    'until-cpp17': <Method_UntilCpp17 />
-    }} />
+	'since-cpp17': <Method_SinceCpp17 />,
+	'until-cpp17': <Method_UntilCpp17 />
+}} />
 
 Inserts element(s) into the container, if the container doesn't already contain an element with an equivalent key.
 

--- a/content/docs/std/containers/maps/unordered-multimap/key_eq.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/key_eq.mdx
@@ -4,21 +4,23 @@ sidebar_label:			key_eq( )
 description:			unordered_multimap<...>::key_eq() method C++ documentation
 hide_title:				true
 tags:					[compare, key_eq, hash, function, hasher]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/key_eq
 ---
 
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- key_eq() -->
-import Method_SinceCpp11 	from './_codes/key_eq/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/key_eq/since-cpp11.mdx';
 
 # std::unordered_multimap key_eq() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the function that compares keys for equality.
 

--- a/content/docs/std/containers/maps/unordered-multimap/load_factor.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/load_factor.mdx
@@ -4,21 +4,23 @@ sidebar_label:			load_factor( )
 description:			unordered_multimap<...>::load_factor() method C++ documentation
 hide_title:				true
 tags:					[load_factor, factor, elements, bucket, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/load_factor
 ---
 
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- load_factor() -->
-import Method_SinceCpp11 	from './_codes/load_factor/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/load_factor/since-cpp11.mdx';
 
 # std::unordered_multimap load_factor() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the average number of elements per bucket, that is, [`size()`](/docs/std/containers/maps/unordered-multimap/size) divided by [`bucket_count()`](/docs/std/containers/unordered-multimap/bucket_count).
 

--- a/content/docs/std/containers/maps/unordered-multimap/max_bucket_count.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/max_bucket_count.mdx
@@ -4,21 +4,23 @@ sidebar_label:			max_bucket_count( )
 description:			unordered_multimap<...>::max_bucket_count() method C++ documentation
 hide_title:				true
 tags:					[max_bucket_count, bucket, count, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/max_bucket_count
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- max_bucket_count() -->
-import Method_SinceCpp11 	from './_codes/max_bucket_count/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/max_bucket_count/since-cpp11.mdx';
 
 # std::unordered_multimap max_bucket_count() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the maximum number of buckets the container is able to hold due to system or library implementation limitations.
 

--- a/content/docs/std/containers/maps/unordered-multimap/max_load_factor.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/max_load_factor.mdx
@@ -4,21 +4,23 @@ sidebar_label:			max_load_factor( )
 description:			unordered_multimap\<...>::max_load_factor() method C++ documentation
 hide_title:				true
 tags:					[max_load_factor, factor, elements, bucket, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/max_load_factor
 ---
 
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- max_load_factor() -->
-import Method_SinceCpp11 	from './_codes/max_load_factor/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/max_load_factor/since-cpp11.mdx';
 
 # std::unordered_multimap\ max_load_factor() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Manages the maximum load factor (number of elements per bucket).
 The container automatically increases the number of buckets if the load factor exceeds this threshold.

--- a/content/docs/std/containers/maps/unordered-multimap/max_size.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/max_size.mdx
@@ -4,21 +4,23 @@ sidebar_label:			max_size( )
 description:			unordered_multimap<...>::max_size() method C++ documentation
 hide_title:				true
 tags:					[max_size, size, elements, amount]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/max_size
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- max_size() -->
-import Method_SinceCpp11 	from './_codes/max_size/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/max_size/since-cpp11.mdx';
 
 # std::unordered_multimap max_size() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the maximum number of elements the container is able to hold due to system or library implementation limitations, i.e. `std::distance(begin(), end())` for the largest container.
 

--- a/content/docs/std/containers/maps/unordered-multimap/merge.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/merge.mdx
@@ -4,20 +4,22 @@ sidebar_label:			merge( )
 description:			unordered_multimap<...>::merge() method C++ documentation
 hide_title:				true
 tags:					[merge, copy, connect, unordered_multimap]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/merge
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp17 	from './_codes/merge/since-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/merge/since-cpp17.mdx';
 
 # std::unordered_multimap merge() method
 
 <SwitchView content={{
-    'since-cpp17': <Method_SinceCpp17 />,
-    }} />
+	'since-cpp17': <Method_SinceCpp17 />,
+}} />
 
 Attempts to extract ("splice") each element in source and insert it into `*this` using the hash function and key equality predicate of `*this`.
 

--- a/content/docs/std/containers/maps/unordered-multimap/operator_assign.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/operator_assign.mdx
@@ -4,24 +4,26 @@ sidebar_label:			operator=
 description:			unordered_multimap<...>::operator= method C++ documentation
 hide_title:				true
 tags:					[unordered_multimap, assign, copy, operator_assign]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/operator=
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- operator_assign() -->
-import Method_UntilCpp17 	from './_codes/operator_assign/until-cpp17.mdx';
-import Method_SinceCpp17 	from './_codes/operator_assign/since-cpp17.mdx';
+import Method_UntilCpp17	from './_codes/operator_assign/until-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/operator_assign/since-cpp17.mdx';
 
-import NoexceptSpecification_SinceCpp17  from './_codes/operator_assign/noexcept-specification/since-cpp17.mdx';
+import NoexceptSpecification_SinceCpp17 from './_codes/operator_assign/noexcept-specification/since-cpp17.mdx';
 
 # std::unordered_multimap operator=
 
 <SwitchView content={{
-    'since-cpp17': <Method_SinceCpp17 />,
-    'until-cpp17': <Method_UntilCpp17 />
+	'since-cpp17': <Method_SinceCpp17 />,
+	'until-cpp17': <Method_UntilCpp17 />
 }} />
 
 Replaces the contents of the container with the contents of another.

--- a/content/docs/std/containers/maps/unordered-multimap/rehash.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/rehash.mdx
@@ -4,10 +4,12 @@ sidebar_label:			rehash( )
 description:			unordered_multimap<...>::rehash() method C++ documentation
 hide_title:				true
 tags:					[rehash, hash, buckets, bucket]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/rehash
 ---
 
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
@@ -17,8 +19,8 @@ import Method_SinceCpp11 	from './_codes/rehash/since-cpp11.mdx';
 # std::unordered_multimap rehash() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 		
 Sets the number of buckets to `count` and rehashes the container, i.e. puts the elements into appropriate buckets considering that total number of buckets has changed.

--- a/content/docs/std/containers/maps/unordered-multimap/reserve.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/reserve.mdx
@@ -4,21 +4,23 @@ sidebar_label:			reserve( )
 description:			unordered_multimap<...>::reserve() method C++ documentation
 hide_title:				true
 tags:					[reserve, buckets, bucket]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/reserve
 ---
 
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- reserve() -->
-import Method_SinceCpp11 	from './_codes/reserve/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/reserve/since-cpp11.mdx';
 
 # std::unordered_multimap reserve() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Sets the number of buckets to the number needed to accomodate at least `count` elements without exceeding maximum load factor and **rehashes the container**,
 i.e. puts the elements into appropriate buckets considering that total number of buckets has changed.

--- a/content/docs/std/containers/maps/unordered-multimap/size.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/size.mdx
@@ -4,21 +4,23 @@ sidebar_label:			size( )
 description:			unordered_multimap<...>::size() method C++ documentation
 hide_title:				true
 tags:					[size, elements, number, amount]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/size
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- size() -->
-import Method_SinceCpp11 	from './_codes/size/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/size/since-cpp11.mdx';
 
 # std::unordered_multimap size() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the number of elements in the container, i.e. `std::distance(begin(), end())`.
 

--- a/content/docs/std/containers/maps/unordered-multimap/swap.mdx
+++ b/content/docs/std/containers/maps/unordered-multimap/swap.mdx
@@ -4,16 +4,18 @@ sidebar_label:			swap( )
 description:			unordered_multimap<...>::swap() method C++ documentation
 hide_title:				true
 tags:					[swap, exchange, unordered_multimap]
+
+cppreference_origin_rel: w/cpp/container/unordered_multimap/swap
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- swap() -->
-import Method_SinceCpp17 	from './_codes/swap/since-cpp17.mdx';
-import Method_UntilCpp17 	from './_codes/swap/until-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/swap/since-cpp17.mdx';
+import Method_UntilCpp17	from './_codes/swap/until-cpp17.mdx';
 
 
 import NoexceptSpecification_SinceCpp17 from './_codes/swap/noexcept-specification/since-cpp17.mdx';
@@ -22,9 +24,9 @@ import PropagateOnContainerChangNote_SineCpp11 from './_codes/swap/explanation/p
 # std::unordered_multimap swap() method
 
 <SwitchView content={{
-    'since-cpp17': <Method_SinceCpp17 />,
-    'until-cpp17': <Method_UntilCpp17 />
-    }} />
+	'since-cpp17': <Method_SinceCpp17 />,
+	'until-cpp17': <Method_UntilCpp17 />
+}} />
 
 Exchanges the contents of the container with those of `other`. Does not invoke any move, copy, or swap operations on individual elements.
 

--- a/content/docs/std/containers/queues/priority-queue.mdx
+++ b/content/docs/std/containers/queues/priority-queue.mdx
@@ -5,29 +5,31 @@ sidebar_label:		priority_queue
 hide_title:			true
 description:		Summary of a std::priority_queue (usage, methods, etc.) - C++ Language
 tags:				[priority_queue, queue, priority, order, comparator]
+
+cppreference_origin_rel: w/cpp/container/priority_queue
 ---
 
 import ClassSummary				from "@site-comps/ClassSummary";
-import CustomCodeBlock				from "@site-comps/CustomCodeBlock";
+import CustomCodeBlock			from "@site-comps/CustomCodeBlock";
 import SymbolTable, { Symbol }	from "@site-comps/SymbolTable";
 import Columns					from "@site-comps/Columns";
 import NotFinished				from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection			from "@site/i18n/en/presets/ImproveSection.mdx";
 import Tabs						from "@theme/Tabs";
-import TabItem						from "@theme/TabItem";
-import Image 						from "@site-comps/Image"
+import TabItem					from "@theme/TabItem";
+import Image 					from "@site-comps/Image"
 
 <!------------------ Codes ----------------->
 
 <!-- Further Examples -->
-import FurtherExamplePushPopPrint from "./priority-queue/_codes/main-page/examples/further/push-pop-print.mdx"
+import FurtherExamplePushPopPrint	from "./priority-queue/_codes/main-page/examples/further/push-pop-print.mdx"
 
 <!-- Overview -->
-import OverviewSimplifiedRegular from "./priority-queue/_codes/main-page/overview/overview-simplified-regular.mdx";
-import OverviewDetailedReguler from "./priority-queue/_codes/main-page/overview/overview-detailed-regular.mdx";
+import OverviewSimplifiedRegular	from "./priority-queue/_codes/main-page/overview/overview-simplified-regular.mdx";
+import OverviewDetailedReguler		from "./priority-queue/_codes/main-page/overview/overview-detailed-regular.mdx";
 
 <!-- Deduction Guides -->
-import DeductionGuides from "./priority-queue/_codes/main-page/deduction-guides.mdx"
+import DeductionGuides				from "./priority-queue/_codes/main-page/deduction-guides.mdx"
 
 <NotFinished />
 

--- a/content/docs/std/containers/queues/queue.mdx
+++ b/content/docs/std/containers/queues/queue.mdx
@@ -5,6 +5,8 @@ sidebar_label:		queue
 hide_title:			true
 description:		Summary of a std::queue (usage, methods, etc.) - C++ Language
 tags:				[queue, adapter, fifo]
+
+cppreference_origin_rel: w/cpp/container/queue
 ---
 
 import ClassSummary				from "@site-comps/ClassSummary";
@@ -13,19 +15,19 @@ import Columns					from "@site-comps/Columns";
 import NotFinished				from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection			from "@site/i18n/en/presets/ImproveSection.mdx";
 import Tabs						from "@theme/Tabs";
-import TabItem						from "@theme/TabItem";
+import TabItem					from "@theme/TabItem";
 
 <!------------------ Codes ----------------->
 
 <!-- Further Examples -->
-import FurtherExamplePushPopPrint from "./priority-queue/_codes/main-page/examples/further/push-pop-print.mdx"
+import FurtherExamplePushPopPrint	from "./priority-queue/_codes/main-page/examples/further/push-pop-print.mdx"
 
 <!-- Overview -->
-import OverviewSimplifiedRegular from "./queue/_codes/main-page/overview/overview-simplified-regular.mdx";
-import OverviewDetailedReguler from "./queue/_codes/main-page/overview/overview-detailed-regular.mdx";
+import OverviewSimplifiedRegular	from "./queue/_codes/main-page/overview/overview-simplified-regular.mdx";
+import OverviewDetailedReguler		from "./queue/_codes/main-page/overview/overview-detailed-regular.mdx";
 
 <!-- Deduction Guides -->
-import DeductionGuides from "./queue/_codes/main-page/deduction-guides.mdx";
+import DeductionGuides				from "./queue/_codes/main-page/deduction-guides.mdx";
 
 <NotFinished />
 

--- a/content/docs/std/containers/sets/multiset.mdx
+++ b/content/docs/std/containers/sets/multiset.mdx
@@ -5,6 +5,8 @@ sidebar_label:		set
 hide_title:			true
 description:		Summary of a std::multiset (usage, methods, etc.) - C++ Language
 tags:				[multiset, multi, many, container, associative, key]
+
+cppreference_origin_rel: w/cpp/container/multiset
 ---
 
 import ClassSummary				from "@site-comps/ClassSummary";

--- a/content/docs/std/containers/sets/multiset/begin.mdx
+++ b/content/docs/std/containers/sets/multiset/begin.mdx
@@ -4,12 +4,14 @@ sidebar_label:			begin( )
 description:			multiset<...>::begin() C++ documentation
 hide_title:				true
 tags:					[access, iterators, begin, get]
+
+cppreference_origin_rel: w/cpp/container/multiset/begin
 ---
 
 import SwitchView				from "@site-comps/SwitchView";
 import Columns					from "@site-comps/Columns";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Tooltip					from "@site-comps/Tooltip";
+import Tabs						from "@theme/Tabs";
 import TabItem					from "@theme/TabItem";
 
 <!-- Terms -->

--- a/content/docs/std/containers/sets/multiset/clear.mdx
+++ b/content/docs/std/containers/sets/multiset/clear.mdx
@@ -4,6 +4,8 @@ sidebar_label:			clear( )
 description:			multiset<...>::clear() method C++ documentation
 hide_title:				true
 tags:					[multiset, clear, empty, erase, remove]
+
+cppreference_origin_rel: w/cpp/container/multiset/clear
 ---
 
 import Columns					from "@site-comps/Columns";
@@ -11,8 +13,8 @@ import SwitchView				from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_UntilCpp11 	from './_codes/clear/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/clear/since-cpp11.mdx';
+import Method_UntilCpp11	from './_codes/clear/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/clear/since-cpp11.mdx';
 
 # std::multiset clear() method
 

--- a/content/docs/std/containers/sets/multiset/constructors.mdx
+++ b/content/docs/std/containers/sets/multiset/constructors.mdx
@@ -4,6 +4,8 @@ sidebar_label:			Constructors
 description:			multiset<...> constructors C++ documentation
 hide_title:				true
 tags:					[constructors, construct, create, multiset, new]
+
+cppreference_origin_rel: w/cpp/container/multiset/multiset
 ---
 
 # std::multiset constructors

--- a/content/docs/std/containers/sets/multiset/contains.mdx
+++ b/content/docs/std/containers/sets/multiset/contains.mdx
@@ -4,14 +4,16 @@ sidebar_label:			contains( )
 description:			multiset<...>::contains() method C++ documentation
 hide_title:				true
 tags:					[multiset, contains, exists]
+
+cppreference_origin_rel: w/cpp/container/multiset/contains
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp20 	from './_codes/contains/since-cpp20.mdx';
+import Method_SinceCpp20	from './_codes/contains/since-cpp20.mdx';
 
 # std::multiset contains() method
 

--- a/content/docs/std/containers/sets/multiset/count.mdx
+++ b/content/docs/std/containers/sets/multiset/count.mdx
@@ -4,15 +4,17 @@ sidebar_label:			count( )
 description:			multiset<...>::count() method C++ documentation
 hide_title:				true
 tags:					[multiset, count, exists, contains]
+
+cppreference_origin_rel: w/cpp/container/multiset/count
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp98 	from './_codes/count/since-cpp98.mdx';
-import Method_SinceCpp14 	from './_codes/count/since-cpp14.mdx';
+import Method_SinceCpp98	from './_codes/count/since-cpp98.mdx';
+import Method_SinceCpp14	from './_codes/count/since-cpp14.mdx';
 
 # std::multiset count() method
 

--- a/content/docs/std/containers/sets/multiset/destructors.mdx
+++ b/content/docs/std/containers/sets/multiset/destructors.mdx
@@ -4,13 +4,15 @@ sidebar_label:			Destructor
 description:			mutliset<...> destructor C++ documentation
 hide_title:				true
 tags:					[destructor, destroy]
+
+cppreference_origin_rel: w/cpp/container/multiset/~multiset
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp98 	from './_codes/destructors/since-cpp98.mdx';
+import Method_SinceCpp98	from './_codes/destructors/since-cpp98.mdx';
 
 # std::multiset destructor
 

--- a/content/docs/std/containers/sets/multiset/emplace.mdx
+++ b/content/docs/std/containers/sets/multiset/emplace.mdx
@@ -4,17 +4,19 @@ sidebar_label:			emplace( )
 description:			multiset<...>::emplace() method C++ documentation
 hide_title:				true
 tags:					[multiset, emplace, insert, add]
+
+cppreference_origin_rel: w/cpp/container/multiset/emplace
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp11 	from './_codes/emplace/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/emplace/since-cpp11.mdx';
 
 # std::multiset emplace() method
 

--- a/content/docs/std/containers/sets/multiset/emplace_hint.mdx
+++ b/content/docs/std/containers/sets/multiset/emplace_hint.mdx
@@ -4,11 +4,13 @@ sidebar_label:			emplace_hint( )
 description:			multiset<...>::emplace_hint() method C++ documentation
 hide_title:				true
 tags:					[multiset, emplace_hint, insert, add]
+
+cppreference_origin_rel: w/cpp/container/multiset/emplace_hint
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import SwitchView			from "@site-comps/SwitchView";
+import Tooltip				from "@site-comps/Tooltip";
+import Tabs					from "@theme/Tabs";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/multiset/empty.mdx
+++ b/content/docs/std/containers/sets/multiset/empty.mdx
@@ -4,16 +4,18 @@ sidebar_label:			empty()
 description:			multiset<...>::empty() method C++ documentation
 hide_title:				true
 tags:					[empty, size]
+
+cppreference_origin_rel: w/cpp/container/multiset/empty
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_UntilCpp11 	from './_codes/empty/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/empty/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/empty/since-cpp20.mdx';
+import Method_UntilCpp11	from './_codes/empty/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/empty/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/empty/since-cpp20.mdx';
 
 # std::multiset empty() method
 

--- a/content/docs/std/containers/sets/multiset/end.mdx
+++ b/content/docs/std/containers/sets/multiset/end.mdx
@@ -4,22 +4,24 @@ sidebar_label:			end( )
 description:			multiset<...>::end() C++ documentation
 hide_title:				true
 tags:					[access, iterators, end, get]
+
+cppreference_origin_rel: w/cpp/container/multiset/end
 ---
 
 import SwitchView				from "@site-comps/SwitchView";
 import Columns					from "@site-comps/Columns";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Tooltip					from "@site-comps/Tooltip";
+import Tabs						from "@theme/Tabs";
 import TabItem					from "@theme/TabItem";
 
 <!-- Terms -->
-import Term_ContAlias_Iterator from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";
-import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
+import Term_ContAlias_Iterator	from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";
+import Term_UndefinedBehaviour	from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
 
 <!----------------- Codes ---------------------->
 
-import Method_UntilCpp11 	from './_codes/end/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/end/since-cpp11.mdx';
+import Method_UntilCpp11		from './_codes/end/until-cpp11.mdx';
+import Method_SinceCpp11		from './_codes/end/since-cpp11.mdx';
 
 # std::multiset end() method
 

--- a/content/docs/std/containers/sets/multiset/equal_range.mdx
+++ b/content/docs/std/containers/sets/multiset/equal_range.mdx
@@ -4,17 +4,19 @@ sidebar_label:			equal_range( )
 description:			multiset<...>::equal_range() method C++ documentation
 hide_title:				true
 tags:					[multiset, equal_range, compare, equal, range]
+
+cppreference_origin_rel: w/cpp/container/multiset/equal_range
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp98 	from './_codes/equal_range/since-cpp98.mdx';
-import Method_SinceCpp14 	from './_codes/equal_range/since-cpp14.mdx';
+import Method_SinceCpp98	from './_codes/equal_range/since-cpp98.mdx';
+import Method_SinceCpp14	from './_codes/equal_range/since-cpp14.mdx';
 
-import ReturnValueOrderNote_SinceCpp11 	from './_codes/equal_range/other/return-value-order-note-since-cpp11.mdx';
+import ReturnValueOrderNote_SinceCpp11 from './_codes/equal_range/other/return-value-order-note-since-cpp11.mdx';
 
 # std::multiset equal_range() method
 

--- a/content/docs/std/containers/sets/multiset/erase.mdx
+++ b/content/docs/std/containers/sets/multiset/erase.mdx
@@ -4,16 +4,18 @@ sidebar_label:			erase( )
 description:			multiset<...>::erase() method C++ documentation
 hide_title:				true
 tags:					[multiset, remove, erase, delete]
+
+cppreference_origin_rel: w/cpp/container/multiset/erase
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_UntilCpp11 	from './_codes/erase/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/erase/since-cpp11.mdx';
-import Method_SinceCpp23 	from './_codes/erase/since-cpp23.mdx';
+import Method_UntilCpp11	from './_codes/erase/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/erase/since-cpp11.mdx';
+import Method_SinceCpp23	from './_codes/erase/since-cpp23.mdx';
 
 # std::multiset erase() method
 

--- a/content/docs/std/containers/sets/multiset/extract.mdx
+++ b/content/docs/std/containers/sets/multiset/extract.mdx
@@ -4,15 +4,17 @@ sidebar_label:			extract( )
 description:			multiset<...>::extract() method C++ documentation
 hide_title:				true
 tags:					[multiset, extract, node_handle]
+
+cppreference_origin_rel: w/cpp/container/multiset/extract
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp17 	from './_codes/extract/since-cpp17.mdx';
-import Method_SinceCpp23 	from './_codes/extract/since-cpp23.mdx';
+import Method_SinceCpp17	from './_codes/extract/since-cpp17.mdx';
+import Method_SinceCpp23	from './_codes/extract/since-cpp23.mdx';
 
 # std::multiset extract() method
 

--- a/content/docs/std/containers/sets/multiset/find.mdx
+++ b/content/docs/std/containers/sets/multiset/find.mdx
@@ -4,15 +4,17 @@ sidebar_label:			find( )
 description:			multiset<...>::find() method C++ documentation
 hide_title:				true
 tags:					[multiset, find, exists, contains, get]
+
+cppreference_origin_rel: w/cpp/container/multiset/find
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp98 	from './_codes/find/since-cpp98.mdx';
-import Method_SinceCpp14 	from './_codes/find/since-cpp14.mdx';
+import Method_SinceCpp98	from './_codes/find/since-cpp98.mdx';
+import Method_SinceCpp14	from './_codes/find/since-cpp14.mdx';
 
 # std::multiset find() method
 

--- a/content/docs/std/containers/sets/multiset/get_allocator.mdx
+++ b/content/docs/std/containers/sets/multiset/get_allocator.mdx
@@ -4,14 +4,16 @@ sidebar_label:			get_allocator
 description:			multiset<...>::get_allocator C++ documentation
 hide_title:				true
 tags:					[allocator, get]
+
+cppreference_origin_rel: w/cpp/container/multiset/get_allocator
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_UntilCpp11 	from './_codes/get_allocator/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/get_allocator/since-cpp11.mdx';
+import Method_UntilCpp11	from './_codes/get_allocator/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/get_allocator/since-cpp11.mdx';
 
 # std::multiset get_allocator() method
 

--- a/content/docs/std/containers/sets/multiset/insert.mdx
+++ b/content/docs/std/containers/sets/multiset/insert.mdx
@@ -4,25 +4,27 @@ sidebar_label:			insert( )
 description:			multiset<...>::insert() method C++ documentation
 hide_title:				true
 tags:					[multiset, insert, add]
+
+cppreference_origin_rel: w/cpp/container/multiset/insert
 ---
 
 import Columns					from "@site-comps/Columns";
 import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Tooltip					from "@site-comps/Tooltip";
+import Tabs						from "@theme/Tabs";
 import ImproveSection			from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!-- Terms -->
-import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
-import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
+import Term_ContAlias_ReverseIterator	from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
+import Term_UndefinedBehaviour			from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
 
 <!----------------- Codes ---------------------->
 
-import Method_UntilCpp11 	from './_codes/insert/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/insert/since-cpp11.mdx';
-import Method_SinceCpp17 	from './_codes/insert/since-cpp17.mdx';
+import Method_UntilCpp11		from './_codes/insert/until-cpp11.mdx';
+import Method_SinceCpp11		from './_codes/insert/since-cpp11.mdx';
+import Method_SinceCpp17		from './_codes/insert/since-cpp17.mdx';
 
-import IteratorDereferenceNote 	from './_codes/insert/explanation/iterator-dereference-note.mdx';
+import IteratorDereferenceNote	from './_codes/insert/explanation/iterator-dereference-note.mdx';
 
 # std::multiset insert() method
 

--- a/content/docs/std/containers/sets/multiset/key_comp.mdx
+++ b/content/docs/std/containers/sets/multiset/key_comp.mdx
@@ -4,20 +4,22 @@ sidebar_label:			key_comp( )
 description:			multiset<...>::key_comp() method C++ documentation
 hide_title:				true
 tags:					[compare, key_comp, key, comp]
+
+cppreference_origin_rel: w/cpp/container/multiset/key_comp
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp98 	from './_codes/key_comp/since-cpp98.mdx';
+import Method_SinceCpp98	from './_codes/key_comp/since-cpp98.mdx';
 
 # std::multiset key_comp() method
 
 <SwitchView content={{
-    'since-cpp98': <Method_SinceCpp98 />,
-    }} />
+		'since-cpp98': <Method_SinceCpp98 />,
+	}} />
 
 Returns the function object that compares the keys, which is a copy of this container's [`constructor`](/docs/std/containers/sets/multiset/constructors) argument `comp`. 
 

--- a/content/docs/std/containers/sets/multiset/lower_bound.mdx
+++ b/content/docs/std/containers/sets/multiset/lower_bound.mdx
@@ -4,6 +4,8 @@ sidebar_label:			lower_bound( )
 description:			multiset<...>::lower_bound() method C++ documentation
 hide_title:				true
 tags:					[multiset, lower_bound, less]
+
+cppreference_origin_rel: w/cpp/container/multiset/lower_bound
 ---
 
 import Columns				from "@site-comps/Columns";
@@ -12,8 +14,8 @@ import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp98 	from './_codes/lower_bound/since-cpp98.mdx';
-import Method_SinceCpp14 	from './_codes/lower_bound/since-cpp14.mdx';
+import Method_SinceCpp98	from './_codes/lower_bound/since-cpp98.mdx';
+import Method_SinceCpp14	from './_codes/lower_bound/since-cpp14.mdx';
 
 # std::multiset lower_bound() method
 

--- a/content/docs/std/containers/sets/multiset/max_size.mdx
+++ b/content/docs/std/containers/sets/multiset/max_size.mdx
@@ -4,15 +4,17 @@ sidebar_label:			max_size( )
 description:			multiset<...>::max_size() method C++ documentation
 hide_title:				true
 tags:					[max, size, max_size]
+
+cppreference_origin_rel: w/cpp/container/multiset/max_size
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_UntilCpp11 	from './_codes/max_size/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/max_size/since-cpp11.mdx';
+import Method_UntilCpp11	from './_codes/max_size/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/max_size/since-cpp11.mdx';
 
 # std::multiset max_size() method
 

--- a/content/docs/std/containers/sets/multiset/merge.mdx
+++ b/content/docs/std/containers/sets/multiset/merge.mdx
@@ -4,21 +4,23 @@ sidebar_label:			merge( )
 description:			multiset<...>::merge() method C++ documentation
 hide_title:				true
 tags:					[multiset, merge, add, copy]
+
+cppreference_origin_rel: w/cpp/container/multiset/merge
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import ImproveSection			from "@site/i18n/en/presets/ImproveSection.mdx";
+import Columns			from "@site-comps/Columns";
+import SwitchView		from "@site-comps/SwitchView";
+import Tooltip			from "@site-comps/Tooltip";
+import Tabs				from "@theme/Tabs";
+import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!-- Terms -->
-import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
-import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
+import Term_ContAlias_ReverseIterator	from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
+import Term_UndefinedBehaviour			from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp17 	from './_codes/merge/since-cpp17.mdx';
+import Method_SinceCpp17 from './_codes/merge/since-cpp17.mdx';
 
 # std::multiset merge() method
 

--- a/content/docs/std/containers/sets/multiset/operator_assign.mdx
+++ b/content/docs/std/containers/sets/multiset/operator_assign.mdx
@@ -4,6 +4,8 @@ sidebar_label:			operator=
 description:			multiset<...>::operator= C++ documentation
 hide_title:				true
 tags:					[assign, replace, copy, set]
+
+cppreference_origin_rel: w/cpp/container/multiset/operator=
 ---
 
 import Columns					from "@site-comps/Columns";
@@ -15,12 +17,12 @@ import Term_ContAlias_Reference	from "@site/i18n/en/presets/terms/cont-alias-ref
 
 <!----------------- Codes ---------------------->
 
-import NoexceptSpecification_SinceCpp17 	from './_codes/operator_assign/noexcept-specification/since-cpp17.mdx';
+import NoexceptSpecification_SinceCpp17 		from './_codes/operator_assign/noexcept-specification/since-cpp17.mdx';
 import PropagateOnContainerChange_SinceCpp11 	from './_codes/operator_assign/explanation/propagate-on-container-change-note-since-cpp11.mdx';
 
-import Method_SinceCpp98 	from './_codes/operator_assign/since-cpp98.mdx';
-import Method_SinceCpp11 	from './_codes/operator_assign/since-cpp11.mdx';
-import Method_SinceCpp17 	from './_codes/operator_assign/since-cpp17.mdx';
+import Method_SinceCpp98 from './_codes/operator_assign/since-cpp98.mdx';
+import Method_SinceCpp11 from './_codes/operator_assign/since-cpp11.mdx';
+import Method_SinceCpp17 from './_codes/operator_assign/since-cpp17.mdx';
 
 # std::multiset operator=
 

--- a/content/docs/std/containers/sets/multiset/rbegin.mdx
+++ b/content/docs/std/containers/sets/multiset/rbegin.mdx
@@ -4,21 +4,23 @@ sidebar_label:			rbegin( )
 description:		    multiset<...>::rbegin() method C++ documentation
 hide_title:				true
 tags:					[access, multiset, iterator, reverse, rbegin, begin]
+
+cppreference_origin_rel: w/cpp/container/multiset/rbegin
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import TabItem					from "@theme/TabItem";
+import Columns		from "@site-comps/Columns";
+import SwitchView	from "@site-comps/SwitchView";
+import Tooltip		from "@site-comps/Tooltip";
+import Tabs			from "@theme/Tabs";
+import TabItem		from "@theme/TabItem";
 
 <!-- Terms -->
 import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
 
 <!----------------- Codes ---------------------->
 
-import Method_UntilCpp11 	from './_codes/rbegin/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/rbegin/since-cpp11.mdx';
+import Method_UntilCpp11 from './_codes/rbegin/until-cpp11.mdx';
+import Method_SinceCpp11 from './_codes/rbegin/since-cpp11.mdx';
 
 # std::multiset rbegin() method
 

--- a/content/docs/std/containers/sets/multiset/rend.mdx
+++ b/content/docs/std/containers/sets/multiset/rend.mdx
@@ -4,22 +4,24 @@ sidebar_label:			rend( )
 description:			multiset<...>::rend() method C++ documentation
 hide_title:				true
 tags:					[access, multiset, rend, end]
+
+cppreference_origin_rel: w/cpp/container/multiset/rend
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import TabItem					from "@theme/TabItem";
+import Columns		from "@site-comps/Columns";
+import SwitchView	from "@site-comps/SwitchView";
+import Tooltip		from "@site-comps/Tooltip";
+import Tabs			from "@theme/Tabs";
+import TabItem		from "@theme/TabItem";
 
 <!-- Terms -->
-import Term_ContAlias_ReverseIterator from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
-import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
+import Term_ContAlias_ReverseIterator	from "@site/i18n/en/presets/terms/cont-alias-reverse-iterator.mdx";
+import Term_UndefinedBehaviour			from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
 
 <!----------------- Codes ---------------------->
 
-import Method_UntilCpp11 	from './_codes/rend/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/rend/since-cpp11.mdx';
+import Method_UntilCpp11 from './_codes/rend/until-cpp11.mdx';
+import Method_SinceCpp11 from './_codes/rend/since-cpp11.mdx';
 
 # std::multiset rend() method
 

--- a/content/docs/std/containers/sets/multiset/size.mdx
+++ b/content/docs/std/containers/sets/multiset/size.mdx
@@ -3,16 +3,18 @@ title:					multiset<...>::size() method
 sidebar_label:			size( )
 description:			multiset<...>::size() method C++ documentation
 hide_title:				true
-tags:					[size]
+tags:					[size, num, count, amount]
+
+cppreference_origin_rel: w/cpp/container/multiset/size
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_UntilCpp11 	from './_codes/size/until-cpp11.mdx';
-import Method_SinceCpp11 	from './_codes/size/since-cpp11.mdx';
+import Method_UntilCpp11	from './_codes/size/until-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/size/since-cpp11.mdx';
 
 # std::multiset size() method
 

--- a/content/docs/std/containers/sets/multiset/swap.mdx
+++ b/content/docs/std/containers/sets/multiset/swap.mdx
@@ -4,18 +4,20 @@ sidebar_label:			swap( )
 description:			multiset<...>::swap() method C++ documentation
 hide_title:				true
 tags:					[multiset, swap]
+
+cppreference_origin_rel: w/cpp/container/multiset/swap
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_UntilCpp17 	from './_codes/swap/until-cpp17.mdx';
-import Method_SinceCpp17 	from './_codes/swap/since-cpp17.mdx';
+import Method_UntilCpp17	from './_codes/swap/until-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/swap/since-cpp17.mdx';
 
-import NoexceptSpecification 	from './_codes/swap/noexcept-specification/since-cpp17.mdx';
-import PropagateOnContainerSwapNote_SinceCpp11 	from './_codes/swap/explanation/propagate-on-container-swap-note-since-cpp11.mdx';
+import NoexceptSpecification					from './_codes/swap/noexcept-specification/since-cpp17.mdx';
+import PropagateOnContainerSwapNote_SinceCpp11	from './_codes/swap/explanation/propagate-on-container-swap-note-since-cpp11.mdx';
 
 # std::multiset swap() method
 

--- a/content/docs/std/containers/sets/multiset/upper_bound.mdx
+++ b/content/docs/std/containers/sets/multiset/upper_bound.mdx
@@ -4,6 +4,8 @@ sidebar_label:			upper_bound( )
 description:			multiset<...>::upper_bound() method C++ documentation
 hide_title:				true
 tags:					[multiset, upper_bound, more, greater]
+
+cppreference_origin_rel: w/cpp/container/multiset/upper_bound
 ---
 
 import Columns				from "@site-comps/Columns";
@@ -12,15 +14,15 @@ import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp98 	from './_codes/upper_bound/since-cpp98.mdx';
-import Method_SinceCpp14 	from './_codes/upper_bound/since-cpp14.mdx';
+import Method_SinceCpp98	from './_codes/upper_bound/since-cpp98.mdx';
+import Method_SinceCpp14	from './_codes/upper_bound/since-cpp14.mdx';
 
 # std::multiset upper_bound() method
 
 <SwitchView content={{
-    'since-cpp14': <Method_SinceCpp14 />,
-    'since-cpp98': <Method_SinceCpp98 />,
-    }} />
+	'since-cpp14': <Method_SinceCpp14 />,
+	'since-cpp98': <Method_SinceCpp98 />,
+}} />
 
  - **(1-2)** Returns an iterator pointing to the first element that is *greater* than `key`.
  - **(3-4)** Returns an iterator pointing to the first element that compares *greater* to the value `x`.

--- a/content/docs/std/containers/sets/multiset/value_comp.mdx
+++ b/content/docs/std/containers/sets/multiset/value_comp.mdx
@@ -4,6 +4,8 @@ sidebar_label:			value_comp( )
 description:			multiset<...>::value_comp() method C++ documentation
 hide_title:				true
 tags:					[compare, value_comp, value, comp]
+
+cppreference_origin_rel: w/cpp/container/multiset/value_comp
 ---
 
 import Columns					from "@site-comps/Columns";
@@ -11,16 +13,16 @@ import SwitchView				from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp98 	from './_codes/value_comp/since-cpp98.mdx';
+import Method_SinceCpp98		from './_codes/value_comp/since-cpp98.mdx';
 
-import ValueComp_Constructor 	from './_codes/value_comp/other/value-comp-constructor.mdx';
-import ValueComp_CallOperator 	from './_codes/value_comp/other/value-comp-call-operator.mdx';
+import ValueComp_Constructor	from './_codes/value_comp/other/value-comp-constructor.mdx';
+import ValueComp_CallOperator	from './_codes/value_comp/other/value-comp-call-operator.mdx';
 
 # std::multiset value_comp() method
 
 <SwitchView content={{
-    'since-cpp98': <Method_SinceCpp98 />,
-    }} />
+	'since-cpp98': <Method_SinceCpp98 />,
+}} />
 
 Returns a function object that compares objects of type `value_type` by comparing the first components of the pairs, same as [`key_comp()`](/docs/std/containers/sets/multiset/key_comp).
 

--- a/content/docs/std/containers/sets/set.mdx
+++ b/content/docs/std/containers/sets/set.mdx
@@ -5,6 +5,8 @@ sidebar_label:		set
 hide_title:			true
 description:		Summary of a std::set (usage, methods, etc.) - C++ Language
 tags:				[set, container, associative, key]
+
+cppreference_origin_rel: w/cpp/container/set
 ---
 
 import ClassSummary				from "@site-comps/ClassSummary";

--- a/content/docs/std/containers/sets/set/begin.mdx
+++ b/content/docs/std/containers/sets/set/begin.mdx
@@ -4,6 +4,8 @@ sidebar_label:			begin( )
 description:			set<...>::begin() C++ documentation
 hide_title:				true
 tags:					[access, iterators, begin, get]
+
+cppreference_origin_rel: w/cpp/container/set/begin
 ---
 
 import SwitchView				from "@site-comps/SwitchView";
@@ -30,7 +32,7 @@ import Method_SinceCpp11 	from './_codes/begin/since-cpp11.mdx';
 	}}/>
 
 Returns an <Tooltip title={Term_ContAlias_Iterator}>iterator</Tooltip> to the first element of the set.
-If the array is empty, the returned iterator will be equal to [`end()`](/docs/std/containers/sets/set/end).
+If the set is empty, the returned iterator will be equal to [`end()`](/docs/std/containers/sets/set/end).
 
 ### Parameters
 

--- a/content/docs/std/containers/sets/set/clear.mdx
+++ b/content/docs/std/containers/sets/set/clear.mdx
@@ -4,10 +4,12 @@ sidebar_label:			clear( )
 description:			set<...>::clear() method C++ documentation
 hide_title:				true
 tags:					[clear, remove, delete, set]
+
+cppreference_origin_rel: w/cpp/container/set/clear
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/set/contains.mdx
+++ b/content/docs/std/containers/sets/set/contains.mdx
@@ -4,10 +4,12 @@ sidebar_label:			contains()
 description:			set<...>::contains() method C++ documentation
 hide_title:				true
 tags:					[contains, existence, exists]
+
+cppreference_origin_rel: w/cpp/container/set/contains
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/set/count.mdx
+++ b/content/docs/std/containers/sets/set/count.mdx
@@ -4,6 +4,8 @@ sidebar_label:			count( )
 description:			set<...>::count() method C++ documentation
 hide_title:				true
 tags:					[count, contains, existence, exists]
+
+cppreference_origin_rel: w/cpp/container/set/count
 ---
 
 import Columns				from "@site-comps/Columns";

--- a/content/docs/std/containers/sets/set/emplace.mdx
+++ b/content/docs/std/containers/sets/set/emplace.mdx
@@ -4,10 +4,12 @@ sidebar_label:			emplace( )
 description:			set<...>::emplace() method C++ documentation
 hide_title:				true
 tags:					[emplace, add, emplace, append, set]
+
+cppreference_origin_rel: w/cpp/container/set/emplace
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/set/emplace_hint.mdx
+++ b/content/docs/std/containers/sets/set/emplace_hint.mdx
@@ -4,6 +4,8 @@ sidebar_label:			emplace_hint( )
 description:			set<...>::emplace_hint() method C++ documentation
 hide_title:				true
 tags:					[emplace_hint, add, emplace, append, set]
+
+cppreference_origin_rel: w/cpp/container/set/emplace_hint
 ---
 
 import Columns				from "@site-comps/Columns";

--- a/content/docs/std/containers/sets/set/empty.mdx
+++ b/content/docs/std/containers/sets/set/empty.mdx
@@ -4,10 +4,12 @@ sidebar_label:			empty( )
 description:			set<...>::empty() method C++ documentation
 hide_title:				true
 tags:					[empty]
+
+cppreference_origin_rel: w/cpp/container/set/empty
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/set/end.mdx
+++ b/content/docs/std/containers/sets/set/end.mdx
@@ -4,6 +4,8 @@ sidebar_label:			end( )
 description:			set<...>::end() C++ documentation
 hide_title:				true
 tags:					[access, iterators, end, get]
+
+cppreference_origin_rel: w/cpp/container/set/end
 ---
 
 import SwitchView				from "@site-comps/SwitchView";
@@ -31,7 +33,7 @@ import Method_SinceCpp11 	from './_codes/end/since-cpp11.mdx';
 	}}/>
 
 Returns an <Tooltip title={Term_ContAlias_Iterator}>iterator</Tooltip> to the element past-the-end of the array.
-If the array is empty, the returned iterator will be equal to [`begin()`](/docs/std/containers/sets/set/begin).
+If the set is empty, the returned iterator will be equal to [`begin()`](/docs/std/containers/sets/set/begin).
 
 Attempting to dereference a past-the-end iterator is <Tooltip title={Term_UndefinedBehaviour}>undefined behaviour</Tooltip>.
 

--- a/content/docs/std/containers/sets/set/equal_range.mdx
+++ b/content/docs/std/containers/sets/set/equal_range.mdx
@@ -4,10 +4,12 @@ sidebar_label:			equal_range( )
 description:			set<...>::equal_range() method C++ documentation
 hide_title:				true
 tags:					[equal_range, equal, range]
+
+cppreference_origin_rel: w/cpp/container/set/equal_range
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/set/erase.mdx
+++ b/content/docs/std/containers/sets/set/erase.mdx
@@ -4,10 +4,12 @@ sidebar_label:			erase( )
 description:			set<...>::erase() method C++ documentation
 hide_title:				true
 tags:					[erase, remove, delete, set]
+
+cppreference_origin_rel: w/cpp/container/set/erase
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/set/extract.mdx
+++ b/content/docs/std/containers/sets/set/extract.mdx
@@ -4,10 +4,12 @@ sidebar_label:			extract( )
 description:			set<...>::extract() method C++ documentation
 hide_title:				true
 tags:					[extract, set]
+
+cppreference_origin_rel: w/cpp/container/set/extract
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/set/find.mdx
+++ b/content/docs/std/containers/sets/set/find.mdx
@@ -3,11 +3,13 @@ title:					set<...>::find() method
 sidebar_label:			find( )
 description:			set<...>::find() method C++ documentation
 hide_title:				true
-tags:					[find, existence, exists]
+tags:					[find, existence, exists, search]
+
+cppreference_origin_rel: w/cpp/container/set/find
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/set/get_allocator.mdx
+++ b/content/docs/std/containers/sets/set/get_allocator.mdx
@@ -4,9 +4,11 @@ sidebar_label:			get_allocator
 description:			set<...>::get_allocator method C++ documentation
 hide_title:				true
 tags:					[set, allocator, get_allocator]
+
+cppreference_origin_rel: w/cpp/container/set/get_allocator
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/set/insert.mdx
+++ b/content/docs/std/containers/sets/set/insert.mdx
@@ -4,6 +4,8 @@ sidebar_label:			insert( )
 description:			set<...>::insert() method C++ documentation
 hide_title:				true
 tags:					[insert, add, append, set]
+
+cppreference_origin_rel: w/cpp/container/set/insert
 ---
 
 import Columns				from "@site-comps/Columns";

--- a/content/docs/std/containers/sets/set/key_comp.mdx
+++ b/content/docs/std/containers/sets/set/key_comp.mdx
@@ -4,6 +4,8 @@ sidebar_label:			key_comp( )
 description:			set<...>::key_comp() method C++ documentation
 hide_title:				true
 tags:					[compare, key_comp, value, comp]
+
+cppreference_origin_rel: w/cpp/container/set/key_comp
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/sets/set/lower_bound.mdx
+++ b/content/docs/std/containers/sets/set/lower_bound.mdx
@@ -4,6 +4,8 @@ sidebar_label:			lower_bound( )
 description:			set<...>::lower_bound() method C++ documentation
 hide_title:				true
 tags:					[bound, lower_bound, lower]
+
+cppreference_origin_rel: w/cpp/container/set/lower_bound
 ---
 
 import SwitchView				from "@site-comps/SwitchView";

--- a/content/docs/std/containers/sets/set/max_size.mdx
+++ b/content/docs/std/containers/sets/set/max_size.mdx
@@ -4,10 +4,12 @@ sidebar_label:			max_size( )
 description:			set<...>::max_size() method C++ documentation
 hide_title:				true
 tags:					[max_size, size, elements, amount]
+
+cppreference_origin_rel: w/cpp/container/set/max_size
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/set/merge.mdx
+++ b/content/docs/std/containers/sets/set/merge.mdx
@@ -4,10 +4,12 @@ sidebar_label:			merge( )
 description:			set<...>::merge() method C++ documentation
 hide_title:				true
 tags:					[merge, copy, connect, set]
+
+cppreference_origin_rel: w/cpp/container/set/merge
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/set/operator_assign.mdx
+++ b/content/docs/std/containers/sets/set/operator_assign.mdx
@@ -4,6 +4,8 @@ sidebar_label:			operator=
 description:			set<...>::operator= C++ documentation
 hide_title:				true
 tags:					[assign, replace, copy, set]
+
+cppreference_origin_rel: w/cpp/container/set/operator=
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/sets/set/rbegin.mdx
+++ b/content/docs/std/containers/sets/set/rbegin.mdx
@@ -4,6 +4,8 @@ sidebar_label:			rbegin( )
 description:		    set<...>::rbegin() method C++ documentation
 hide_title:				true
 tags:					[access, set, iterator, reverse, rbegin, begin]
+
+cppreference_origin_rel: w/cpp/container/set/rbegin
 ---
 
 import Columns					from "@site-comps/Columns";
@@ -28,11 +30,11 @@ import Method_SinceCpp11 	from './_codes/end/since-cpp11.mdx';
         'until-cpp11': <Method_UntilCpp11 />,
     }}/>
 
-Returns a <Tooltip title={Term_ContAlias_ReverseIterator}>reverse iterator</Tooltip> to the first element of the reversed vector.
-It corresponds to the last element of the non-reversed vector.
+Returns a <Tooltip title={Term_ContAlias_ReverseIterator}>reverse iterator</Tooltip> to the first element of the reversed container.
+It corresponds to the last element of the non-reversed container.
 
 :::note
-This method doesn't actually reverse the vector, it just returns an iterator that points to the last element of the vector,
+This method doesn't actually reverse the container, it just returns an iterator that points to the last element of it,
 and whose `+`, `-`, `--`, `++` operators have slightly changed implementations.
 
 For example `it++` decrements the internal pointer and `it--` increments it (so that traversing the container in a reverse order actually works).

--- a/content/docs/std/containers/sets/set/rend.mdx
+++ b/content/docs/std/containers/sets/set/rend.mdx
@@ -4,12 +4,14 @@ sidebar_label:			rend( )
 description:			set<...>::rend() method C++ documentation
 hide_title:				true
 tags:					[access, set, rend, end]
+
+cppreference_origin_rel: w/cpp/container/set/rend
 ---
 
 import Columns					from "@site-comps/Columns";
 import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Tooltip					from "@site-comps/Tooltip";
+import Tabs						from "@theme/Tabs";
 import TabItem					from "@theme/TabItem";
 
 <!-- Terms -->
@@ -25,20 +27,20 @@ import Method_SinceCpp11 	from './_codes/rend/since-cpp11.mdx';
 # std::set rend() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    'until-cpp11': <Method_UntilCpp11 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+	'until-cpp11': <Method_UntilCpp11 />,
 }} />
 
-It corresponds to the last element of the non-reversed vector.
+It corresponds to the last element of the non-reversed container.
 
-Returns a <Tooltip title={Term_ContAlias_ReverseIterator}>reverse iterator</Tooltip> to the last element of the reversed vector.
-It corresponds to the element **preceding** the first element of the non-reversed vector.
+Returns a <Tooltip title={Term_ContAlias_ReverseIterator}>reverse iterator</Tooltip> to the last element of the container.
+It corresponds to the element **preceding** the first element of the non-reversed container.
 
-It effectively returns an iterator that points past the end of the original vector. 
+It effectively returns an iterator that points past the end of the original container. 
 Attempting to dereference a past-the-end iterator is <Tooltip title={Term_UndefinedBehaviour}>undefined behaviour</Tooltip>.
 
 :::note
-This method doesn't actually reverse the vector, it just returns an iterator that points to the element before the first element of the array,
+This method doesn't actually reverse the container, it just returns an iterator that points to the element before the first element of it,
 and whose `+`, `-`, `--`, `++` operators have slightly changed implementations.
 
 For example `it++` decrements the internal pointer and `it--` increments it (so that traversing the container in a reverse order actually works).
@@ -75,10 +77,10 @@ For non-const container of type `c` they return different iterators:
 
 int main()
 {
-    std::set<int> set = {1, 2, 3, 4, 5};
-    auto it = set.rend(); // Type: std::set<int>::reverse_iterator
-    // highlight-next-line
-    *std::prev(it) = 5; // ✔ Ok
+	std::set<int> set = {1, 2, 3, 4, 5};
+	auto it = set.rend(); // Type: std::set<int>::reverse_iterator
+	// highlight-next-line
+	*std::prev(it) = 5; // ✔ Ok
 }
 ```
 
@@ -90,10 +92,10 @@ int main()
 
 int main()
 {
-    std::set<int> set = {1, 2, 3, 4, 5};
-    auto it = set.crend(); // Type: std::set<int>::const_reverse_iterator
-    // error-next-line
-    *std::prev(it) = 5; // ❌ Error! 
+	std::set<int> set = {1, 2, 3, 4, 5};
+	auto it = set.crend(); // Type: std::set<int>::const_reverse_iterator
+	// error-next-line
+	*std::prev(it) = 5; // ❌ Error! 
 }
 ```
 
@@ -111,10 +113,10 @@ int main()
 
 int main()
 {
-    const std::set<int> set = {1, 2, 3, 4, 5};
-    auto it = set.rend(); // Type: std::set<int>::const_reverse_iterator
-    // error-next-line
-    *std::prev(it) = 5; // ❌ Error! 
+	const std::set<int> set = {1, 2, 3, 4, 5};
+	auto it = set.rend(); // Type: std::set<int>::const_reverse_iterator
+	// error-next-line
+	*std::prev(it) = 5; // ❌ Error! 
 }
 ```
 
@@ -126,10 +128,10 @@ int main()
 
 int main()
 {
-    const std::set<int> set = {1, 2, 3, 4, 5};
-    auto it = set.crend(); // Type: std::set<int>::const_reverse_iterator
-    // error-next-line
-    *std::prev(it) = 5; // ❌ Error! 
+	const std::set<int> set = {1, 2, 3, 4, 5};
+	auto it = set.crend(); // Type: std::set<int>::const_reverse_iterator
+	// error-next-line
+	*std::prev(it) = 5; // ❌ Error! 
 }
 ```
 
@@ -151,13 +153,13 @@ int main()
  
 int main()
 {
-    std::set<unsigned> rep{1, 2, 3, 4, 1, 2, 3, 4};
+	std::set<unsigned> rep{1, 2, 3, 4, 1, 2, 3, 4};
  
-    for (auto it = rep.crbegin(); it != rep.crend(); ++it) {
-        for (auto n = *it; n > 0; --n)
-            std::cout << "⏼" << ' ';
-        std::cout << '\n';
-    }
+	for (auto it = rep.crbegin(); it != rep.crend(); ++it) {
+		for (auto n = *it; n > 0; --n)
+			std::cout << "⏼" << ' ';
+		std::cout << '\n';
+	}
 }
 ```
 

--- a/content/docs/std/containers/sets/set/size.mdx
+++ b/content/docs/std/containers/sets/set/size.mdx
@@ -4,10 +4,12 @@ sidebar_label:			size( )
 description:			set<...>::size() method C++ documentation
 hide_title:				true
 tags:					[size, elements, number, amount]
+
+cppreference_origin_rel: w/cpp/container/set/size
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/set/swap.mdx
+++ b/content/docs/std/containers/sets/set/swap.mdx
@@ -4,10 +4,12 @@ sidebar_label:			swap( )
 description:			set<...>::swap() method C++ documentation
 hide_title:				true
 tags:					[swap, exchange, set]
+
+cppreference_origin_rel: w/cpp/container/set/swap
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/set/upper_bound.mdx
+++ b/content/docs/std/containers/sets/set/upper_bound.mdx
@@ -4,6 +4,8 @@ sidebar_label:			upper_bound( )
 description:			set<...>::upper_bound() method C++ documentation
 hide_title:				true
 tags:					[upper, upper_bound, bound]
+
+cppreference_origin_rel: w/cpp/container/set/upper_bound
 ---
 
 import SwitchView				from "@site-comps/SwitchView";

--- a/content/docs/std/containers/sets/set/value_comp.mdx
+++ b/content/docs/std/containers/sets/set/value_comp.mdx
@@ -4,6 +4,8 @@ sidebar_label:			value_comp( )
 description:			set<...>::value_comp() method C++ documentation
 hide_title:				true
 tags:					[compare, value_comp, value, comp]
+
+cppreference_origin_rel: w/cpp/container/set/value_comp
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/sets/unordered-multiset.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset.mdx
@@ -4,6 +4,8 @@ title:				std::unordered_multiset reference
 sidebar_label:		unordered_multiset
 tags:				[unordered_multiset, set, container, unordered, associative, container, key]
 hide_title:			true
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset
 ---
 
 import ClassSummary				from "@site-comps/ClassSummary";

--- a/content/docs/std/containers/sets/unordered-multiset.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset.mdx
@@ -9,9 +9,9 @@ cppreference_origin_rel: w/cpp/container/unordered_multiset
 ---
 
 import ClassSummary				from "@site-comps/ClassSummary";
-import CustomCodeBlock				from "@site-comps/CustomCodeBlock";
+import CustomCodeBlock			from "@site-comps/CustomCodeBlock";
 import SymbolTable, { Symbol }	from "@site-comps/SymbolTable";
-import SwitchView 		from "@site-comps/SwitchView"
+import SwitchView				from "@site-comps/SwitchView"
 import Columns					from "@site-comps/Columns";
 import NotFinished				from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection			from "@site/i18n/en/presets/ImproveSection.mdx";

--- a/content/docs/std/containers/sets/unordered-multiset/begin.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/begin.mdx
@@ -4,13 +4,15 @@ sidebar_label:			begin( )
 description:			unordered_multiset<...>::begin() method C++ documentation
 hide_title:				true
 tags:					[access, unordered_multiset, iterator, begin, front]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/begin
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
-import TabItem					from "@theme/TabItem";
+import Columns		from "@site-comps/Columns";
+import SwitchView	from "@site-comps/SwitchView";
+import Tooltip		from "@site-comps/Tooltip";
+import Tabs			from "@theme/Tabs";
+import TabItem		from "@theme/TabItem";
 
 <!-- Terms -->
 import Term_ContAlias_Iterator from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";
@@ -18,7 +20,7 @@ import Term_ContAlias_Iterator from "@site/i18n/en/presets/terms/cont-alias-iter
 <!----------------- Codes ---------------------->
 
 <!-- begin() -->
-import Method_SinceCpp11 	from './_codes/begin/since-cpp11.mdx';
+import Method_SinceCpp11 from './_codes/begin/since-cpp11.mdx';
 
 # std::unordered_multiset begin()/cbegin() method
 

--- a/content/docs/std/containers/sets/unordered-multiset/begin_size_type.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/begin_size_type.mdx
@@ -4,15 +4,17 @@ sidebar_label:			begin( size_type )
 description:			unordered_multiset<...>::begin( size_type ) method C++ documentation
 hide_title:				true
 tags:					[iterator, access, bucket]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/begin2
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView		from "@site-comps/SwitchView";
 import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- begin( size_type ) -->
-import Method_SinceCpp11 	from './_codes/begin_size_type/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/begin_size_type/since-cpp11.mdx';
 
 # std::unordered_multiset begin( size_type ) method
 

--- a/content/docs/std/containers/sets/unordered-multiset/bucket.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/bucket.mdx
@@ -4,21 +4,23 @@ sidebar_label:			bucket( )
 description:			unordered_multiset<...>::bucket() method C++ documentation
 hide_title:				true
 tags:					[bucket, index, count, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/bucket
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- bucket() -->
-import Method_SinceCpp11 	from './_codes/bucket/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/bucket/since-cpp11.mdx';
 
 # std::unordered_multiset bucket() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the index of the bucket for key `key`.
 Elements (if any) with keys equivalent to `key` are always found in this bucket.

--- a/content/docs/std/containers/sets/unordered-multiset/bucket_count.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/bucket_count.mdx
@@ -4,15 +4,17 @@ sidebar_label:			bucket_count( )
 description:			unordered_multiset<...>::bucket_count() method C++ documentation
 hide_title:				true
 tags:					[bucket_count, bucket, count, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/bucket_count
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- bucket_count() -->
-import Method_SinceCpp11 	from './_codes/bucket_count/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/bucket_count/since-cpp11.mdx';
 
 # std::unordered_multiset bucket_count() method
 

--- a/content/docs/std/containers/sets/unordered-multiset/bucket_size.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/bucket_size.mdx
@@ -4,15 +4,17 @@ sidebar_label:			bucket_size( )
 description:			unordered_multiset<...>::bucket_size() method C++ documentation
 hide_title:				true
 tags:					[bucket_size, bucket, count, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/bucket_size
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- bucket_size() -->
-import Method_SinceCpp11 	from './_codes/bucket_size/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/bucket_size/since-cpp11.mdx';
 
 # std::unordered_multiset bucket_size() method
 

--- a/content/docs/std/containers/sets/unordered-multiset/clear.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/clear.mdx
@@ -4,15 +4,17 @@ sidebar_label:			clear( )
 description:			unordered_multiset<...>::clear() method C++ documentation
 hide_title:				true
 tags:					[clear, remove, delete, unordered_multiset]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/clear
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- clear() -->
-import Method_SinceCpp11 	from './_codes/clear/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/clear/since-cpp11.mdx';
 
 # std::unordered_multiset clear() method
 

--- a/content/docs/std/containers/sets/unordered-multiset/constructors.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/constructors.mdx
@@ -4,6 +4,8 @@ sidebar_label:			Constructors
 description:			unordered_multimap<...> constructors C++ documentation
 hide_title:				true
 tags:					[constructors, construct, create, unordered_multiset, new]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/unordered_multiset
 ---
 
 # std::unordered_multiset constructors

--- a/content/docs/std/containers/sets/unordered-multiset/contains.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/contains.mdx
@@ -4,15 +4,17 @@ sidebar_label:			contains( )
 description:			unordered_multiset<...>::contains() method C++ documentation
 hide_title:				true
 tags:					[contains, existence, exists]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/contains
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- contains() -->
-import Method_SinceCpp20 	from './_codes/contains/since-cpp20.mdx';
+import Method_SinceCpp20	from './_codes/contains/since-cpp20.mdx';
 
 # std::unordered_multiset contains() method
 

--- a/content/docs/std/containers/sets/unordered-multiset/count.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/count.mdx
@@ -4,23 +4,25 @@ sidebar_label:			count( )
 description:			unordered_multiset<...>::count() method C++ documentation
 hide_title:				true
 tags:					[count, contains, existence, exists]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/count
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- count() -->
-import Method_SinceCpp11 	from './_codes/count/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/count/since-cpp20.mdx';
+import Method_SinceCpp11	from './_codes/count/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/count/since-cpp20.mdx';
 
 # std::unordered_multiset count() method
 
 <SwitchView content={{
-    'since-cpp20': <Method_SinceCpp20 />,
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 
  - **(1)** Returns the number of elements with key that compares equal to the specified argument `key`.

--- a/content/docs/std/containers/sets/unordered-multiset/destructors.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/destructors.mdx
@@ -4,16 +4,18 @@ sidebar_label:		Destructor
 description:		unordered_multiset<...> destructor C++ documentation
 hide_title:			true
 tags:				[unordered_multiset, destruction, destructor]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/~unordered_multiset
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 import Method_SinceCpp11 	from './_codes/destructors/since-cpp11.mdx';
 
 # std::unordered_multiset destructors
 
 <SwitchView content={{
-        'since-cpp11': <Method_SinceCpp11 />,
+	'since-cpp11': <Method_SinceCpp11 />,
 }} />
 
 Destructs the `unordered_multiset`.

--- a/content/docs/std/containers/sets/unordered-multiset/emplace.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/emplace.mdx
@@ -4,21 +4,23 @@ sidebar_label:			emplace( )
 description:			unordered_multiset<...>::emplace() method C++ documentation
 hide_title:				true
 tags:					[emplace, add, emplace, append, unordered_multiset]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/emplace
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- emplace() -->
-import Method_SinceCpp11 	from './_codes/emplace/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/emplace/since-cpp11.mdx';
 
 # std::unordered_multiset emplace() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Inserts a new element into the container constructed in-place with the given `args` if there is no element with the key in the container.
 

--- a/content/docs/std/containers/sets/unordered-multiset/emplace_hint.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/emplace_hint.mdx
@@ -4,16 +4,18 @@ sidebar_label:			emplace_hint( )
 description:			unordered_multiset<...>::emplace_hint() method C++ documentation
 hide_title:				true
 tags:					[emplace_hint, add, emplace, append, unordered_multiset]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/emplace_hint
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- emplace_hint() -->
-import Method_SinceCpp11 	from './_codes/emplace_hint/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/emplace_hint/since-cpp11.mdx';
 
 # std::unordered_multiset emplace_hint() method
 

--- a/content/docs/std/containers/sets/unordered-multiset/empty.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/empty.mdx
@@ -4,23 +4,25 @@ sidebar_label:			empty( )
 description:			unordered_multiset<...>::empty() method C++ documentation
 hide_title:				true
 tags:					[empty]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/empty
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- empty() -->
-import Method_UntilCpp20 	from './_codes/empty/until-cpp20.mdx';
-import Method_SinceCpp20 	from './_codes/empty/since-cpp20.mdx';
+import Method_UntilCpp20	from './_codes/empty/until-cpp20.mdx';
+import Method_SinceCpp20	from './_codes/empty/since-cpp20.mdx';
 
 # std::unordered_multiset empty() method
 
 <SwitchView content={{
-        'since-cpp20': <Method_SinceCpp20 />,
-        'until-cpp20': <Method_UntilCpp20 />,
-    }} />
+	'since-cpp20': <Method_SinceCpp20 />,
+	'until-cpp20': <Method_UntilCpp20 />,
+}} />
 
 Checks if the container has no elements, i.e. whether `begin() == end()`.
 

--- a/content/docs/std/containers/sets/unordered-multiset/end.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/end.mdx
@@ -4,28 +4,30 @@ sidebar_label:			end( )
 description:			unordered_multiset<...>::end() method C++ documentation
 hide_title:				true
 tags:					[access, unordered_multiset, iterator, end, back]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/end
 ---
 
 import Columns					from "@site-comps/Columns";
 import SwitchView				from "@site-comps/SwitchView";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Tooltip					from "@site-comps/Tooltip";
+import Tabs						from "@theme/Tabs";
 import TabItem					from "@theme/TabItem";
 
 <!-- Terms -->
-import Term_ContAlias_Iterator from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";
-import Term_UndefinedBehaviour from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
+import Term_ContAlias_Iterator	from "@site/i18n/en/presets/terms/cont-alias-iterator.mdx";
+import Term_UndefinedBehaviour	from "@site/i18n/en/presets/terms/undefined-behaviour.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- end() -->
-import Method_SinceCpp11 	from './_codes/end/since-cpp11.mdx';
+import Method_SinceCpp11		from './_codes/end/since-cpp11.mdx';
 
 # std::unordered_multiset begin()/cbegin() method
 
 <SwitchView content={{
-        'since-cpp11': <Method_SinceCpp11 />,
-    }}/>
+		'since-cpp11': <Method_SinceCpp11 />,
+}}/>
 
 Returns an <Tooltip title={Term_ContAlias_Iterator}>iterator</Tooltip> to the element past-the-end of the unordered_multiset.
 If the unordered_multiset is empty, the returned iterator will be equal to [`begin()`](/docs/std/containers/sets/unordered-multiset/begin).

--- a/content/docs/std/containers/sets/unordered-multiset/end_size_type.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/end_size_type.mdx
@@ -4,21 +4,23 @@ sidebar_label:			end( size_type )
 description:			unordered_multiset<...>::end( size_type ) method C++ documentation
 hide_title:				true
 tags:					[iterator, access, bucket]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/end
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- end( size_type ) -->
-import Method_SinceCpp11 	from './_codes/end_size_type/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/end_size_type/since-cpp11.mdx';
 
 # std::unordered_multiset end( size_type ) method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns an iterator to the element following the last element of the bucket with index `n`.
 

--- a/content/docs/std/containers/sets/unordered-multiset/equal_range.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/equal_range.mdx
@@ -4,29 +4,31 @@ sidebar_label:			equal_range( )
 description:			unordered_multiset<...>::equal_range() method C++ documentation
 hide_title:				true
 tags:					[equal_range, equal, range]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/equal_range
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- equal_range() -->
-import Method_SinceCpp11 	from './_codes/equal_range/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/equal_range/since-cpp20.mdx';
+import Method_SinceCpp11	from './_codes/equal_range/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/equal_range/since-cpp20.mdx';
 
 # std::unordered_multiset equal_range() method
 
 <SwitchView content={{
-    'since-cpp20': <Method_SinceCpp20 />,
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
- - **(1-2)** Returns a range containing all elements with key `key` in the container.
-    The range is defined by two iterators, the first pointing to the first element of the wanted range and the second pointing past the last element of the range.
- - **(3-4)** Returns a range containing all elements in the container with key equivalent to `x`.
-    This overload participates in overload resolution only if `Hash::is_transparent` and `KeyEqual::is_transparent` are valid and each denotes a type.
-    This assumes that such `Hash` is callable with both `K` and `Key` type, and that the `KeyEqual` is transparent, which, together, allows calling this function without constructing an instance of `Key`.
+- **(1-2)** Returns a range containing all elements with key `key` in the container.
+  The range is defined by two iterators, the first pointing to the first element of the wanted range and the second pointing past the last element of the range.
+- **(3-4)** Returns a range containing all elements in the container with key equivalent to `x`.
+  This overload participates in overload resolution only if `Hash::is_transparent` and `KeyEqual::is_transparent` are valid and each denotes a type.
+  This assumes that such `Hash` is callable with both `K` and `Key` type, and that the `KeyEqual` is transparent, which, together, allows calling this function without constructing an instance of `Key`.
 
 ### Parameters
 

--- a/content/docs/std/containers/sets/unordered-multiset/erase.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/erase.mdx
@@ -4,31 +4,33 @@ sidebar_label:			erase( )
 description:			unordered_multiset<...>::erase() method C++ documentation
 hide_title:				true
 tags:					[erase, remove, delete, unordered_multiset]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/erase
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- erase() -->
-import Method_SinceCpp11 	from './_codes/erase/since-cpp11.mdx';
-import Method_SinceCpp23 	from './_codes/erase/since-cpp23.mdx';
+import Method_SinceCpp11	from './_codes/erase/since-cpp11.mdx';
+import Method_SinceCpp23	from './_codes/erase/since-cpp23.mdx';
 
 # std::unordered_multiset erase() method
 
 <SwitchView content={{
-    'since-cpp23': <Method_SinceCpp23 />,
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp23': <Method_SinceCpp23 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
- - **(1)** Removes the element at `pos`. Only one overload is provided if `iterator` and `const_iterator` are the same type.
- - **(2)** Removes the elements in the range **[ first; last )**, which must be a valid range in `*this`.
- - **(3)** Removes the element (if one exists) with the key equivalent to `key`.
- - **(4)** Removes the element (if one exists) with key that compares equivalent to the value `x`.
-   This overload participates in overload resolution only if `Hash::is_transparent` and `KeyEqual::is_transparent` are valid and each denotes a type,
-   and neither `iterator` nor `const_iterator` is implicitly convertible from `K`.
-   This assumes that such Hash is callable with both `K` and `Key` type, and that the `KeyEqual` is transparent, which, together, allows calling this function without constructing an instance of `Key`.
+- **(1)** Removes the element at `pos`. Only one overload is provided if `iterator` and `const_iterator` are the same type.
+- **(2)** Removes the elements in the range **[ first; last )**, which must be a valid range in `*this`.
+- **(3)** Removes the element (if one exists) with the key equivalent to `key`.
+- **(4)** Removes the element (if one exists) with key that compares equivalent to the value `x`.
+  This overload participates in overload resolution only if `Hash::is_transparent` and `KeyEqual::is_transparent` are valid and each denotes a type,
+  and neither `iterator` nor `const_iterator` is implicitly convertible from `K`.
+  This assumes that such Hash is callable with both `K` and `Key` type, and that the `KeyEqual` is transparent, which, together, allows calling this function without constructing an instance of `Key`.
 
 
 The order of the elements that are not erased is preserved (this makes it possible to erase individual elements while iterating through the container).

--- a/content/docs/std/containers/sets/unordered-multiset/extract.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/extract.mdx
@@ -4,22 +4,24 @@ sidebar_label:			extract( )
 description:			unordered_multiset<...>::extract() method C++ documentation
 hide_title:				true
 tags:					[extract, unordered_multiset]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/extract
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp17 	from './_codes/extract/since-cpp17.mdx';
-import Method_SinceCpp23 	from './_codes/extract/since-cpp23.mdx';
+import Method_SinceCpp17	from './_codes/extract/since-cpp17.mdx';
+import Method_SinceCpp23	from './_codes/extract/since-cpp23.mdx';
 
 # std::unordered_multiset extract() method
 
 <SwitchView content={{
-    'since-cpp23': <Method_SinceCpp23 />,
-    'since-cpp17': <Method_SinceCpp17 />,
-    }} />
+	'since-cpp23': <Method_SinceCpp23 />,
+	'since-cpp17': <Method_SinceCpp17 />,
+}} />
 
  - **(1)**
     Unlinks the node that contains the element pointed to by position and returns a node handle that owns it.

--- a/content/docs/std/containers/sets/unordered-multiset/find.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/find.mdx
@@ -4,23 +4,25 @@ sidebar_label:			find( )
 description:			unordered_multiset<...>::find() method C++ documentation
 hide_title:				true
 tags:					[find, existence, exists]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/find
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- find() -->
-import Method_SinceCpp11 	from './_codes/find/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/find/since-cpp20.mdx';
+import Method_SinceCpp11	from './_codes/find/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/find/since-cpp20.mdx';
 
 # std::unordered_multiset find() method
 
 <SwitchView content={{
-    'since-cpp20': <Method_SinceCpp20 />,
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp20': <Method_SinceCpp20 />,
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
  - **(1-2)** Finds an element with key equivalent to `key`.
  - **(3-4)** Finds an element with key that compares equivalent to the value `x`.

--- a/content/docs/std/containers/sets/unordered-multiset/get_allocator.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/get_allocator.mdx
@@ -4,14 +4,16 @@ sidebar_label:			get_allocator( )
 description:			unordered_multiset<...>::get_allocator method C++ documentation
 hide_title:				true
 tags:					[unordered_multiset, allocator, get_allocator]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/get_allocator
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- get_allocator() -->
-import Method_SinceCpp11 	from './_codes/get_allocator/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/get_allocator/since-cpp11.mdx';
 
 # std::unordered_multiset get_allocator() method
 

--- a/content/docs/std/containers/sets/unordered-multiset/hash_function.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/hash_function.mdx
@@ -4,21 +4,23 @@ sidebar_label:			hash_function( )
 description:			unordered_multiset<...>::hash_function() method C++ documentation
 hide_title:				true
 tags:					[compare, hash_function, hash, function, hasher]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/hash_function
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- hash_function() -->
-import Method_SinceCpp11 	from './_codes/hash_function/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/hash_function/since-cpp11.mdx';
 
 # std::unordered_multiset hash_function() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the function that hashes the keys.
 

--- a/content/docs/std/containers/sets/unordered-multiset/insert.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/insert.mdx
@@ -4,64 +4,52 @@ sidebar_label:			insert( )
 description:			unordered_multiset<...>::insert() method C++ documentation
 hide_title:				true
 tags:					[insert, add, append, unordered_multiset]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/insert
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- insert() -->
-import Method_SinceCpp17 	from './_codes/insert/since-cpp17.mdx';
-import Method_UntilCpp17 	from './_codes/insert/until-cpp17.mdx';
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
+import Method_SinceCpp17	from './_codes/insert/since-cpp17.mdx';
+import Method_UntilCpp17	from './_codes/insert/until-cpp17.mdx';
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
-import IteratorDereferenceNote_UntilCpp17 	from './_codes/insert/explanation/iterator-dereference-note-until-cpp17.mdx';
-import IteratorDereferenceNote_SinceCpp17 	from './_codes/insert/explanation/iterator-dereference-note-since-cpp17.mdx';
+import IteratorDereferenceNote_UntilCpp17 from './_codes/insert/explanation/iterator-dereference-note-until-cpp17.mdx';
+import IteratorDereferenceNote_SinceCpp17 from './_codes/insert/explanation/iterator-dereference-note-since-cpp17.mdx';
 
 # std::unordered_multiset insert() method
 
 <SwitchView content={{
-    'since-cpp17': <Method_SinceCpp17 />,
-    'until-cpp17': <Method_UntilCpp17 />
-    }} />
+	'since-cpp17': <Method_SinceCpp17 />,
+	'until-cpp17': <Method_UntilCpp17 />
+}} />
 
 Inserts element(s) into the container, if the container doesn't already contain an element with an equivalent key.
 
- - **(1-2)** Inserts value.
+- **(1-2)** Inserts value.
+- **(3-4)** Inserts value, using hint as a non-binding suggestion to where the search should start.
+- **(5)** Inserts elements from range **[ first; last )**.
+- **(6)** Inserts elements from initializer list `ilist`.
+- **(7)** If `nh` is an empty node handle, does nothing. 
+  Otherwise, inserts the element owned by `nh` into the container, if the container doesn't already contain an element with a key equivalent to `nh.key()`. 
+  <span className="inline-danger">The behavior is undefined if <code>nh</code> is not empty and <code>get_allocator() != nh.get_allocator()</code>.</span>
+- **(8)**
+  If `nh` is an empty node handle, does nothing and returns the end iterator.
+  Otherwise, inserts the element owned by `nh` into the container, if the container doesn't already contain an element with a key equivalent to `nh.key()`,
+  and returns the iterator pointing to the element with key equivalent to `nh.key()` (regardless of whether the insert succeeded or failed).
+  If the insertion succeeds, `nh` is moved from, otherwise it retains ownership of the element. 
+  The element is inserted as close as possible to `hint`. 
+  <span className="inline-danger">The behavior is undefined if <code>nh</code> is not empty and <code>get_allocator() != nh.get_allocator()</code>.</span>
 
- - **(3-4)** Inserts value, using hint as a non-binding suggestion to where the search should start.
-
- - **(5)** Inserts elements from range **[ first; last )**.
-
- - **(6)** Inserts elements from initializer list `ilist`.
-
- - **(7)**
-    If `nh` is an empty node handle, does nothing. 
-
-    Otherwise, inserts the element owned by `nh` into the container, if the container doesn't already contain an element with a key equivalent to `nh.key()`.
-
-:::danger Undefined behaviour
-The behavior is undefined if `nh` is not empty and `get_allocator() != nh.get_allocator()`.
-:::
-
- - **(8)**
-    If `nh` is an empty node handle, does nothing and returns the end iterator.
-    
-    Otherwise, inserts the element owned by `nh` into the container, if the container doesn't already contain an element with a key equivalent to `nh.key()`,
-    and returns the iterator pointing to the element with key equivalent to `nh.key()` (regardless of whether the insert succeeded or failed).
-
-    If the insertion succeeds, `nh` is moved from, otherwise it retains ownership of the element. 
-    The element is inserted as close as possible to `hint`.
-    
-:::danger Undefined behaviour
-The behavior is undefined if `nh` is not empty and `get_allocator() != nh.get_allocator()`.
-:::
 
 
 <SwitchView content={{
-    'since-cpp17': <IteratorDereferenceNote_SinceCpp17 />,
-    'until-cpp17': <IteratorDereferenceNote_UntilCpp17 />,
-    }} />
+	'since-cpp17': <IteratorDereferenceNote_SinceCpp17 />,
+	'until-cpp17': <IteratorDereferenceNote_UntilCpp17 />,
+}} />
 
 ### Parameters
 
@@ -83,17 +71,15 @@ The behavior is undefined if `nh` is not empty and `get_allocator() != nh.get_al
 
 ### Complexity
 
- - **(1-4)**  
-   Average case, constant - **O(1)**.  
-   Worst case, linear in the size of the container - **O(size())**.
-
- - **(5-6)**  
-   Average case, linear in the number of elements to insert - **O(N)**, where N is the number of elements to insert.  
-   Worst case - **O(N*size()+N)**, where N is the number of elements to insert.
-
- - **(7-8)**  
-   Average case, constant - **O(1)**.  
-   Worst case, linear in the size of the container - **O(size())**.
+- **(1-4)**  
+  Average case, constant - **O(1)**.  
+  Worst case, linear in the size of the container - **O(size())**.
+- **(5-6)**  
+  Average case, linear in the number of elements to insert - **O(N)**, where N is the number of elements to insert.  
+  Worst case - **O(N*size()+N)**, where N is the number of elements to insert.
+- **(7-8)**  
+  Average case, constant - **O(1)**.  
+  Worst case, linear in the size of the container - **O(size())**.
 
 
 ### Exceptions

--- a/content/docs/std/containers/sets/unordered-multiset/key_eq.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/key_eq.mdx
@@ -4,21 +4,23 @@ sidebar_label:			key_eq( )
 description:			unordered_multiset<...>::key_eq() method C++ documentation
 hide_title:				true
 tags:					[compare, key_eq, hash, function, hasher]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/key_eq
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- key_eq() -->
-import Method_SinceCpp11 	from './_codes/key_eq/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/key_eq/since-cpp11.mdx';
 
 # std::unordered_multiset key_eq() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the function that compares keys for equality.
 

--- a/content/docs/std/containers/sets/unordered-multiset/load_factor.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/load_factor.mdx
@@ -4,20 +4,22 @@ sidebar_label:			load_factor( )
 description:			unordered_multiset<...>::load_factor() method C++ documentation
 hide_title:				true
 tags:					[load_factor, factor, elements, bucket, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/load_factor
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp11 	from './_codes/load_factor/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/load_factor/since-cpp11.mdx';
 
 # std::unordered_multiset load_factor() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the average number of elements per bucket, that is, [`size()`](/docs/std/containers/sets/unordered-multiset/size) divided by [`bucket_count()`](/docs/std/containers/sets/unordered-multiset/bucket_count).
 

--- a/content/docs/std/containers/sets/unordered-multiset/max_bucket_count.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/max_bucket_count.mdx
@@ -4,21 +4,23 @@ sidebar_label:			max_bucket_count( )
 description:			unordered_multiset<...>::max_bucket_count() method C++ documentation
 hide_title:				true
 tags:					[max_bucket_count, bucket, count, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/max_bucket_count
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- max_bucket_count() -->
-import Method_SinceCpp11 	from './_codes/max_bucket_count/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/max_bucket_count/since-cpp11.mdx';
 
 # std::unordered_multiset max_bucket_count() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the maximum number of buckets the container is able to hold due to system or library implementation limitations.
 

--- a/content/docs/std/containers/sets/unordered-multiset/max_load_factor.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/max_load_factor.mdx
@@ -4,14 +4,16 @@ sidebar_label:			max_load_factor( )
 description:			unordered_multiset\<...>::max_load_factor() method C++ documentation
 hide_title:				true
 tags:					[max_load_factor, factor, elements, bucket, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/max_load_factor
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp11 	from './_codes/max_load_factor/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/max_load_factor/since-cpp11.mdx';
 
 # std::unordered_multiset max_load_factor() method
 

--- a/content/docs/std/containers/sets/unordered-multiset/max_size.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/max_size.mdx
@@ -1,24 +1,26 @@
 ---
-title:					unordered_multiset<...>::ax_size() method
+title:					unordered_multiset<...>::max_size() method
 sidebar_label:			max_size( )
 description:			unordered_multiset<...>::max_size() method C++ documentation
 hide_title:				true
 tags:					[max_size, size, elements, amount]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/max_size
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- max_size() -->
-import Method_SinceCpp11 	from './_codes/max_size/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/max_size/since-cpp11.mdx';
 
 # std::unordered_multiset max_size() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the maximum number of elements the container is able to hold due to system or library implementation limitations, i.e. `std::distance(begin(), end())` for the largest container.
 

--- a/content/docs/std/containers/sets/unordered-multiset/merge.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/merge.mdx
@@ -4,20 +4,22 @@ sidebar_label:			merge( )
 description:			unordered_multiset<...>::merge() method C++ documentation
 hide_title:				true
 tags:					[merge, copy, connect, unordered_multiset]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/merge
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp17 	from './_codes/merge/since-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/merge/since-cpp17.mdx';
 
 # std::unordered_multiset merge() method
 
 <SwitchView content={{
-    'since-cpp17': <Method_SinceCpp17 />,
-    }} />
+	'since-cpp17': <Method_SinceCpp17 />,
+}} />
 
 Attempts to extract ("splice") each element in source and insert it into `*this` using the hash function and key equality predicate of `*this`.
 

--- a/content/docs/std/containers/sets/unordered-multiset/operator_assign.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/operator_assign.mdx
@@ -4,10 +4,12 @@ sidebar_label:			operator=
 description:			unordered_multiset<...>::operator= method C++ documentation
 hide_title:				true
 tags:					[unordered_multiset, assign, copy, operator_assign]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/operator=
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
@@ -20,37 +22,29 @@ import NoexceptSpecification_SinceCpp17  from './_codes/operator_assign/noexcept
 # std::unordered_multiset operator=
 
 <SwitchView content={{
-    'since-cpp17': <Method_SinceCpp17 />,
-    'until-cpp17': <Method_UntilCpp17 />
+	'since-cpp17': <Method_SinceCpp17 />,
+	'until-cpp17': <Method_UntilCpp17 />
 }} />
 
 Replaces the contents of the container with the contents of another.
 
- - **(1)** **Copy** assignment operator. Replaces the contents with a copy of the contents of `other`.
-    If `std::allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value` is `true`, the allocator of `*this` is replaced by a copy of that of `other`.
-
-    If the allocator of `*this` after assignment would compare unequal to its old value, the old allocator is used to deallocate the memory,
-    then the new allocator is used to allocate it before copying the elements.
-
-    Otherwise, the memory owned by `*this` may be reused when possible. In any case, the elements originally belong to `*this` may be either destroyed or replaced by element-wise copy-assignment.
-
- - **(2)** **Move** assignment operator. Replaces the contents with those of other using move semantics (i.e. the data in other is moved from other into this container).
-:::important
-`other` is in a valid but unspecified state afterwards.
-:::
-    If `std::allocator_traits<Alloc>::propagate_on_container_move_assignment::value` is `true`, the allocator of `*this` is replaced by a copy of that of other.
-
-    If it is false and the allocators of `*this` and other do not compare equal, `*this` cannot take ownership of the memory owned by other and must move-assign each element individually,
-    allocating additional memory using its own allocator as needed.
-
-    In any case, all elements originally belong to `*this` are either destroyed or replaced by element-wise move-assignment.
-
- - **(3)** Replaces the contents with those identified by initializer list `ilist`.
+- **(1)** **Copy** assignment operator. Replaces the contents with a copy of the contents of `other`.
+  If `std::allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value` is `true`, the allocator of `*this` is replaced by a copy of that of `other`.
+  If the allocator of `*this` after assignment would compare unequal to its old value, the old allocator is used to deallocate the memory,
+  then the new allocator is used to allocate it before copying the elements.
+  Otherwise, the memory owned by `*this` may be reused when possible. In any case, the elements originally belong to `*this` may be either destroyed or replaced by element-wise copy-assignment.
+- **(2)** **Move** assignment operator. Replaces the contents with those of other using move semantics (i.e. the data in other is moved from other into this container). 
+  <span className="inline-note"><code>other</code> is in a valid but unspecified state afterwards.</span>
+  If <code>std::allocator_traits&lt;Alloc&gt;::propagate_on_container_move_assignment::value</code> is <code>true</code>, the allocator of <code>*this</code> is replaced by a copy of that of other.  
+  If it is false and the allocators of <code>*this</code> and other do not compare equal, <code>*this</code> cannot take ownership of the memory owned by other and must move-assign each element individually,
+  allocating additional memory using its own allocator as needed.
+  In any case, all elements originally belong to <code>*this</code> are either destroyed or replaced by element-wise move-assignment.
+- **(3)** Replaces the contents with those identified by initializer list `ilist`.
 
 ### Parameters
 
- - `other` - another container to use as data source
- - `ilist` - initializer list to use as data source
+- `other` - another container to use as data source
+- `ilist` - initializer list to use as data source
  
 ### Return value
 
@@ -58,20 +52,20 @@ Replaces the contents of the container with the contents of another.
 
 ### Complexity
 
- - **(1)** Linear in the size of `*this` and `other` - **O(size() + other.size())**
- - **(2)**  
-	Linear in the size of `*this` - **O(size())**.  
-	If the allocators do not compare equal and do not propagate, linear in the size of `*this` and other - **O(size() + other.size())**.
- - **(3)** Linear in the size of `*this` and `ilist` - **O(size() + ilist.size())**.
+- **(1)** Linear in the size of `*this` and `other` - **O(size() + other.size())**
+- **(2)**  
+  Linear in the size of `*this` - **O(size())**.  
+  If the allocators do not compare equal and do not propagate, linear in the size of `*this` and other - **O(size() + other.size())**.
+- **(3)** Linear in the size of `*this` and `ilist` - **O(size() + ilist.size())**.
 
 ### Exceptions
 
 <SwitchView content={{
-        'since-cpp17': <NoexceptSpecification_SinceCpp17 />,
-        'until-cpp17': <> 
-        May throw implementation-defined exceptions.
-        </>
-    }} />
+	'since-cpp17': <NoexceptSpecification_SinceCpp17 />,
+	'until-cpp17': <> 
+		May throw implementation-defined exceptions.
+	</>
+}} />
 
 ### Notes
 

--- a/content/docs/std/containers/sets/unordered-multiset/rehash.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/rehash.mdx
@@ -4,20 +4,22 @@ sidebar_label:			rehash( )
 description:			unordered_multiset<...>::rehash() method C++ documentation
 hide_title:				true
 tags:					[rehash, hash, buckets, bucket]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/rehash
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp11 	from './_codes/rehash/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/rehash/since-cpp11.mdx';
 
 # std::unordered_multiset rehash() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 		
 Sets the number of buckets to `count` and rehashes the container, i.e. puts the elements into appropriate buckets considering that total number of buckets has changed.

--- a/content/docs/std/containers/sets/unordered-multiset/reserve.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/reserve.mdx
@@ -4,15 +4,17 @@ sidebar_label:			reserve( )
 description:			unordered_multiset<...>::reserve() method C++ documentation
 hide_title:				true
 tags:					[reserve, buckets, bucket]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/reserve
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
+import SwitchView			from "@site-comps/SwitchView";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- reserve() -->
-import Method_SinceCpp11 	from './_codes/reserve/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/reserve/since-cpp11.mdx';
 
 # std::unordered_multiset reserve() method
 

--- a/content/docs/std/containers/sets/unordered-multiset/size.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/size.mdx
@@ -4,21 +4,23 @@ sidebar_label:			size( )
 description:			unordered_multiset<...>::size() method C++ documentation
 hide_title:				true
 tags:					[size, elements, number, amount]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/size
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- size() -->
-import Method_SinceCpp11 	from './_codes/size/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/size/since-cpp11.mdx';
 
 # std::unordered_multiset size() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+}} />
 
 Returns the number of elements in the container, i.e. `std::distance(begin(), end())`.
 

--- a/content/docs/std/containers/sets/unordered-multiset/swap.mdx
+++ b/content/docs/std/containers/sets/unordered-multiset/swap.mdx
@@ -4,27 +4,29 @@ sidebar_label:			swap( )
 description:			unordered_multiset<...>::swap() method C++ documentation
 hide_title:				true
 tags:					[swap, exchange, unordered_multiset]
+
+cppreference_origin_rel: w/cpp/container/unordered_multiset/swap
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- swap() -->
-import Method_SinceCpp17 	from './_codes/swap/since-cpp17.mdx';
-import Method_UntilCpp17 	from './_codes/swap/until-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/swap/since-cpp17.mdx';
+import Method_UntilCpp17	from './_codes/swap/until-cpp17.mdx';
 
 
-import NoexceptSpecification_SinceCpp17 from './_codes/swap/noexcept-specification/since-cpp17.mdx';
-import PropagateOnContainerChangNote_SineCpp11 from './_codes/swap/explanation/propagate-on-container-change-note-since-cpp11.mdx';
+import NoexceptSpecification_SinceCpp17			from './_codes/swap/noexcept-specification/since-cpp17.mdx';
+import PropagateOnContainerChangNote_SineCpp11	from './_codes/swap/explanation/propagate-on-container-change-note-since-cpp11.mdx';
 
 # std::unordered_multiset swap() method
 
 <SwitchView content={{
-    'since-cpp17': <Method_SinceCpp17 />,
-    'until-cpp17': <Method_UntilCpp17 />
-    }} />
+	'since-cpp17': <Method_SinceCpp17 />,
+	'until-cpp17': <Method_UntilCpp17 />
+}} />
 
 Exchanges the contents of the container with those of `other`. Does not invoke any move, copy, or swap operations on individual elements.
 

--- a/content/docs/std/containers/sets/unordered-set.mdx
+++ b/content/docs/std/containers/sets/unordered-set.mdx
@@ -4,6 +4,8 @@ title:				std::unordered_set reference
 sidebar_label:		unordered_set
 tags:				[unordered_set, set, container, unordered, associative, container, key]
 hide_title:			true
+
+cppreference_origin_rel: w/cpp/container/unordered_set
 ---
 
 import ClassSummary				from "@site-comps/ClassSummary";

--- a/content/docs/std/containers/sets/unordered-set.mdx
+++ b/content/docs/std/containers/sets/unordered-set.mdx
@@ -9,9 +9,9 @@ cppreference_origin_rel: w/cpp/container/unordered_set
 ---
 
 import ClassSummary				from "@site-comps/ClassSummary";
-import CustomCodeBlock				from "@site-comps/CustomCodeBlock";
+import CustomCodeBlock			from "@site-comps/CustomCodeBlock";
 import SymbolTable, { Symbol }	from "@site-comps/SymbolTable";
-import SwitchView 		from "@site-comps/SwitchView"
+import SwitchView 				from "@site-comps/SwitchView"
 import Columns					from "@site-comps/Columns";
 import NotFinished				from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection			from "@site/i18n/en/presets/ImproveSection.mdx";

--- a/content/docs/std/containers/sets/unordered-set/begin.mdx
+++ b/content/docs/std/containers/sets/unordered-set/begin.mdx
@@ -4,6 +4,8 @@ sidebar_label:			begin( )
 description:			unordered_set<...>::begin() C++ documentation
 hide_title:				true
 tags:					[access, iterators, begin, get]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/begin
 ---
 
 import SwitchView				from "@site-comps/SwitchView";

--- a/content/docs/std/containers/sets/unordered-set/begin_size_type.mdx
+++ b/content/docs/std/containers/sets/unordered-set/begin_size_type.mdx
@@ -4,10 +4,12 @@ sidebar_label:			begin( size_type )
 description:			unordered_set<...>::begin( size_type ) method C++ documentation
 hide_title:				true
 tags:					[iterator, access, bucket]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/begin2
 ---
 
 import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView		from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/unordered-set/bucket.mdx
+++ b/content/docs/std/containers/sets/unordered-set/bucket.mdx
@@ -4,10 +4,12 @@ sidebar_label:			bucket( )
 description:			unordered_set<...>::bucket() method C++ documentation
 hide_title:				true
 tags:					[bucket, index, count, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/bucket
 ---
 
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
@@ -17,8 +19,8 @@ import Method_SinceCpp11 	from './_codes/bucket/since-cpp11.mdx';
 # std::unordered_set bucket() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+	}} />
 
 Returns the index of the bucket for key `key`.
 Elements (if any) with keys equivalent to `key` are always found in this bucket.

--- a/content/docs/std/containers/sets/unordered-set/bucket_count.mdx
+++ b/content/docs/std/containers/sets/unordered-set/bucket_count.mdx
@@ -4,6 +4,8 @@ sidebar_label:			bucket_count( )
 description:			unordered_set<...>::bucket_count() method C++ documentation
 hide_title:				true
 tags:					[bucket_count, bucket, count, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/bucket_count
 ---
 
 import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';

--- a/content/docs/std/containers/sets/unordered-set/bucket_size.mdx
+++ b/content/docs/std/containers/sets/unordered-set/bucket_size.mdx
@@ -4,10 +4,12 @@ sidebar_label:			bucket_size( )
 description:			unordered_set<...>::bucket_size() method C++ documentation
 hide_title:				true
 tags:					[bucket_size, bucket, count, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/bucket_size
 ---
 
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
@@ -17,8 +19,8 @@ import Method_SinceCpp11 	from './_codes/bucket_size/since-cpp11.mdx';
 # std::unordered_set bucket_size() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+	}} />
 
 Returns the number of elements in the bucket with index `n`.
 

--- a/content/docs/std/containers/sets/unordered-set/clear.mdx
+++ b/content/docs/std/containers/sets/unordered-set/clear.mdx
@@ -4,10 +4,12 @@ sidebar_label:			clear( )
 description:			unordered_set<...>::clear() method C++ documentation
 hide_title:				true
 tags:					[clear, remove, delete, unordered_set]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/clear
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
@@ -17,8 +19,8 @@ import Method_SinceCpp11 	from './_codes/clear/since-cpp11.mdx';
 # std::unordered_set clear() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+	}} />
 
 Erases all elements from the container. After this call, [`size()`](/docs/containers/sets/unordered-set/size) returns zero.
 
@@ -56,20 +58,20 @@ Linear in the size of the container - **O(1)**.
  
 int main()
 {
-    std::unordered_set<int> container{1, 2, 3};
+	std::unordered_set<int> container{1, 2, 3};
  
-    auto print = [](const int& n) { std::cout << " " << n; };
+	auto print = [](const int& n) { std::cout << " " << n; };
  
-    std::cout << "Before clear:";
-    std::for_each(container.begin(), container.end(), print);
-    std::cout << "\nSize=" << container.size() << '\n';
+	std::cout << "Before clear:";
+	std::for_each(container.begin(), container.end(), print);
+	std::cout << "\nSize=" << container.size() << '\n';
  
-    std::cout << "Clear\n";
-    container.clear();
+	std::cout << "Clear\n";
+	container.clear();
  
-    std::cout << "After clear:";
-    std::for_each(container.begin(), container.end(), print);
-    std::cout << "\nSize=" << container.size() << '\n';
+	std::cout << "After clear:";
+	std::for_each(container.begin(), container.end(), print);
+	std::cout << "\nSize=" << container.size() << '\n';
 }
 ```
 

--- a/content/docs/std/containers/sets/unordered-set/constructors.mdx
+++ b/content/docs/std/containers/sets/unordered-set/constructors.mdx
@@ -4,6 +4,8 @@ sidebar_label:			Constructors
 description:			unordered_set<...> constructors C++ documentation
 hide_title:				true
 tags:					[constructors, construct, create, unordered_set, new]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/unordered_set
 ---
 
 # std::unordered_set constructors

--- a/content/docs/std/containers/sets/unordered-set/contains.mdx
+++ b/content/docs/std/containers/sets/unordered-set/contains.mdx
@@ -4,10 +4,12 @@ sidebar_label:			contains( )
 description:			unordered_set<...>::contains() method C++ documentation
 hide_title:				true
 tags:					[contains, existence, exists]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/contains
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/unordered-set/count.mdx
+++ b/content/docs/std/containers/sets/unordered-set/count.mdx
@@ -4,10 +4,12 @@ sidebar_label:			count( )
 description:			unordered_set<...>::count() method C++ documentation
 hide_title:				true
 tags:					[count, contains, existence, exists]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/count
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/unordered-set/destructors.mdx
+++ b/content/docs/std/containers/sets/unordered-set/destructors.mdx
@@ -6,7 +6,7 @@ hide_title:			true
 tags:				[unordered_set, destruction, destructor]
 ---
 
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!-- destructors -->
 import Method_SinceCpp11 	from './_codes/destructors/since-cpp11.mdx';

--- a/content/docs/std/containers/sets/unordered-set/emplace.mdx
+++ b/content/docs/std/containers/sets/unordered-set/emplace.mdx
@@ -4,12 +4,14 @@ sidebar_label:			emplace( )
 description:			unordered_set<...>::emplace() method C++ documentation
 hide_title:				true
 tags:					[emplace, add, emplace, append, unordered_set]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/emplace
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
-import ImproveSection from "@site/i18n/en/presets/ImproveSection.mdx";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
@@ -19,8 +21,8 @@ import Method_SinceCpp11 	from './_codes/emplace/since-cpp11.mdx';
 # std::unordered_set emplace() method
 
 <SwitchView content={{
-    'since-cpp11': <Method_SinceCpp11 />,
-    }} />
+	'since-cpp11': <Method_SinceCpp11 />,
+	}} />
 
 Inserts a new element into the container constructed in-place with the given `args` if there is no element with the key in the container.
 

--- a/content/docs/std/containers/sets/unordered-set/emplace_hint.mdx
+++ b/content/docs/std/containers/sets/unordered-set/emplace_hint.mdx
@@ -4,11 +4,13 @@ sidebar_label:			emplace_hint( )
 description:			unordered_set<...>::emplace_hint() method C++ documentation
 hide_title:				true
 tags:					[emplace_hint, add, emplace, append, unordered_set]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/emplace_hint
 ---
 
 import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns			from "@site-comps/Columns";
+import SwitchView		from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/unordered-set/empty.mdx
+++ b/content/docs/std/containers/sets/unordered-set/empty.mdx
@@ -4,10 +4,12 @@ sidebar_label:			empty( )
 description:			unordered_set<...>::empty() method C++ documentation
 hide_title:				true
 tags:					[empty]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/empty
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/unordered-set/end.mdx
+++ b/content/docs/std/containers/sets/unordered-set/end.mdx
@@ -4,12 +4,14 @@ sidebar_label:			end( )
 description:			unordered_set<...>::end() C++ documentation
 hide_title:				true
 tags:					[access, iterators, end, get]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/end
 ---
 
 import SwitchView				from "@site-comps/SwitchView";
 import Columns					from "@site-comps/Columns";
-import Tooltip				    from "@site-comps/Tooltip";
-import Tabs				        from "@theme/Tabs";
+import Tooltip					from "@site-comps/Tooltip";
+import Tabs						from "@theme/Tabs";
 import TabItem					from "@theme/TabItem";
 
 <!-- Terms -->

--- a/content/docs/std/containers/sets/unordered-set/end_size_type.mdx
+++ b/content/docs/std/containers/sets/unordered-set/end_size_type.mdx
@@ -4,10 +4,12 @@ sidebar_label:			end( size_type )
 description:			unordered_set<...>::end( size_type ) method C++ documentation
 hide_title:				true
 tags:					[iterator, access, bucket]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/end2
 ---
 
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/unordered-set/equal_range.mdx
+++ b/content/docs/std/containers/sets/unordered-set/equal_range.mdx
@@ -4,12 +4,14 @@ sidebar_label:			equal_range( )
 description:			unordered_set<...>::equal_range() method C++ documentation
 hide_title:				true
 tags:					[equal_range, equal, range]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/equal_range
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
-import ImproveSection from "@site/i18n/en/presets/ImproveSection.mdx";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/unordered-set/erase.mdx
+++ b/content/docs/std/containers/sets/unordered-set/erase.mdx
@@ -4,16 +4,18 @@ sidebar_label:			erase( )
 description:			unordered_set<...>::erase() method C++ documentation
 hide_title:				true
 tags:					[erase, remove, delete, unordered_set]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/erase
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- erase() -->
-import Method_SinceCpp11    from './_codes/erase/since-cpp11.mdx';
-import Method_SinceCpp23 	from './_codes/erase/since-cpp23.mdx';
+import Method_SinceCpp11	from './_codes/erase/since-cpp11.mdx';
+import Method_SinceCpp23	from './_codes/erase/since-cpp23.mdx';
 
 # std::unordered_set erase() method
 

--- a/content/docs/std/containers/sets/unordered-set/extract.mdx
+++ b/content/docs/std/containers/sets/unordered-set/extract.mdx
@@ -4,15 +4,17 @@ sidebar_label:			extract( )
 description:			unordered_set<...>::extract() method C++ documentation
 hide_title:				true
 tags:					[extract, unordered_set]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/extract
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp17 	from './_codes/extract/since-cpp17.mdx';
-import Method_SinceCpp23 	from './_codes/extract/since-cpp23.mdx';
+import Method_SinceCpp17	from './_codes/extract/since-cpp17.mdx';
+import Method_SinceCpp23	from './_codes/extract/since-cpp23.mdx';
 
 # std::unordered_set extract() method
 

--- a/content/docs/std/containers/sets/unordered-set/find.mdx
+++ b/content/docs/std/containers/sets/unordered-set/find.mdx
@@ -3,17 +3,19 @@ title:					unordered_set<...>::find() method
 sidebar_label:			find( )
 description:			unordered_set<...>::find() method C++ documentation
 hide_title:				true
-tags:					[find, existence, exists]
+tags:					[find, existence, exists, search]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/find
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- find() -->
-import Method_SinceCpp11 	from './_codes/find/since-cpp11.mdx';
-import Method_SinceCpp20 	from './_codes/find/since-cpp20.mdx';
+import Method_SinceCpp11	from './_codes/find/since-cpp11.mdx';
+import Method_SinceCpp20	from './_codes/find/since-cpp20.mdx';
 
 # std::unordered_set find() method
 

--- a/content/docs/std/containers/sets/unordered-set/get_allocator.mdx
+++ b/content/docs/std/containers/sets/unordered-set/get_allocator.mdx
@@ -4,10 +4,12 @@ sidebar_label:			get_allocator( )
 description:			unordered_set<...>::get_allocator method C++ documentation
 hide_title:				true
 tags:					[unordered_set, allocator, get_allocator]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/get_allocator
 ---
 
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/unordered-set/hash_function.mdx
+++ b/content/docs/std/containers/sets/unordered-set/hash_function.mdx
@@ -4,15 +4,17 @@ sidebar_label:			hash_function( )
 description:			unordered_set<...>::hash_function() method C++ documentation
 hide_title:				true
 tags:					[compare, hash_function, hash, function, hasher]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/hash_function
 ---
 
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- hash_function() -->
-import Method_SinceCpp11 	from './_codes/hash_function/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/hash_function/since-cpp11.mdx';
 
 # std::unordered_set hash_function() method
 

--- a/content/docs/std/containers/sets/unordered-set/insert.mdx
+++ b/content/docs/std/containers/sets/unordered-set/insert.mdx
@@ -4,18 +4,20 @@ sidebar_label:			insert( )
 description:			unordered_set<...>::insert() method C++ documentation
 hide_title:				true
 tags:					[insert, add, append, unordered_set]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/insert
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
-import ImproveSection from "@site/i18n/en/presets/ImproveSection.mdx";
+import ImproveSection		from "@site/i18n/en/presets/ImproveSection.mdx";
 
 <!----------------- Codes ---------------------->
 
 <!-- insert() -->
-import Method_SinceCpp17 	from './_codes/insert/since-cpp17.mdx';
-import Method_UntilCpp17 	from './_codes/insert/until-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/insert/since-cpp17.mdx';
+import Method_UntilCpp17	from './_codes/insert/until-cpp17.mdx';
 
 import IteratorDereferenceNote_UntilCpp17 	from './_codes/insert/explanation/iterator-dereference-note-until-cpp17.mdx';
 import IteratorDereferenceNote_SinceCpp17 	from './_codes/insert/explanation/iterator-dereference-note-since-cpp17.mdx';

--- a/content/docs/std/containers/sets/unordered-set/key_eq.mdx
+++ b/content/docs/std/containers/sets/unordered-set/key_eq.mdx
@@ -4,15 +4,17 @@ sidebar_label:			key_eq( )
 description:			unordered_set<...>::key_eq() method C++ documentation
 hide_title:				true
 tags:					[compare, key_eq, hash, function, hasher]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/key_eq
 ---
 
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- key_eq() -->
-import Method_SinceCpp11 	from './_codes/key_eq/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/key_eq/since-cpp11.mdx';
 
 # std::unordered_set key_eq() method
 

--- a/content/docs/std/containers/sets/unordered-set/load_factor.mdx
+++ b/content/docs/std/containers/sets/unordered-set/load_factor.mdx
@@ -4,15 +4,17 @@ sidebar_label:			load_factor( )
 description:			unordered_set<...>::load_factor() method C++ documentation
 hide_title:				true
 tags:					[load_factor, factor, elements, bucket, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/load_factor
 ---
 
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- load_factor() -->
-import Method_SinceCpp11 	from './_codes/load_factor/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/load_factor/since-cpp11.mdx';
 
 # std::unordered_set load_factor() method
 

--- a/content/docs/std/containers/sets/unordered-set/max_bucket_count.mdx
+++ b/content/docs/std/containers/sets/unordered-set/max_bucket_count.mdx
@@ -4,15 +4,17 @@ sidebar_label:			max_bucket_count( )
 description:			unordered_set<...>::max_bucket_count() method C++ documentation
 hide_title:				true
 tags:					[max_bucket_count, bucket, count, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/max_bucket_count
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- max_bucket_count() -->
-import Method_SinceCpp11 	from './_codes/max_bucket_count/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/max_bucket_count/since-cpp11.mdx';
 
 # std::unordered_set max_bucket_count() method
 

--- a/content/docs/std/containers/sets/unordered-set/max_load_factor.mdx
+++ b/content/docs/std/containers/sets/unordered-set/max_load_factor.mdx
@@ -4,15 +4,17 @@ sidebar_label:			max_load_factor( )
 description:			unordered_set<...>::max_load_factor() method C++ documentation
 hide_title:				true
 tags:					[max_load_factor, factor, elements, bucket, buckets]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/max_load_factor
 ---
 
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- max_load_factor() -->
-import Method_SinceCpp11 	from './_codes/max_load_factor/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/max_load_factor/since-cpp11.mdx';
 
 # std::unordered_set max_load_factor() method
 

--- a/content/docs/std/containers/sets/unordered-set/max_size.mdx
+++ b/content/docs/std/containers/sets/unordered-set/max_size.mdx
@@ -4,10 +4,12 @@ sidebar_label:			max_size( )
 description:			unordered_set<...>::max_size() method C++ documentation
 hide_title:				true
 tags:					[max_size, size, elements, amount]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/max_size
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/unordered-set/merge.mdx
+++ b/content/docs/std/containers/sets/unordered-set/merge.mdx
@@ -4,14 +4,16 @@ sidebar_label:			merge( )
 description:			unordered_set<...>::merge() method C++ documentation
 hide_title:				true
 tags:					[merge, copy, connect, unordered_set]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/merge
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
-import Method_SinceCpp17 	from './_codes/merge/since-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/merge/since-cpp17.mdx';
 
 # std::unordered_set merge() method
 

--- a/content/docs/std/containers/sets/unordered-set/operator_assign.mdx
+++ b/content/docs/std/containers/sets/unordered-set/operator_assign.mdx
@@ -4,16 +4,18 @@ sidebar_label:			operator=
 description:			unordered_set<...>::operator= method C++ documentation
 hide_title:				true
 tags:					[unordered_set, assign, copy, operator_assign]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/operator=
 ---
 
-import Columns					from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import Columns				from "@site-comps/Columns";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- operator_assign() -->
-import Method_UntilCpp17 	from './_codes/operator_assign/until-cpp17.mdx';
-import Method_SinceCpp17 	from './_codes/operator_assign/since-cpp17.mdx';
+import Method_UntilCpp17	from './_codes/operator_assign/until-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/operator_assign/since-cpp17.mdx';
 
 import NoexceptSpecification_SinceCpp17  from './_codes/operator_assign/noexcept-specification/since-cpp17.mdx';
 

--- a/content/docs/std/containers/sets/unordered-set/rehash.mdx
+++ b/content/docs/std/containers/sets/unordered-set/rehash.mdx
@@ -4,10 +4,12 @@ sidebar_label:			rehash( )
 description:			unordered_set<...>::rehash() method C++ documentation
 hide_title:				true
 tags:					[rehash, hash, buckets, bucket]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/rehash
 ---
 
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/unordered-set/reserve.mdx
+++ b/content/docs/std/containers/sets/unordered-set/reserve.mdx
@@ -4,10 +4,12 @@ sidebar_label:			reserve( )
 description:			unordered_set<...>::reserve() method C++ documentation
 hide_title:				true
 tags:					[reserve, buckets, bucket]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/reserve
 ---
 
-import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-import SwitchView				from "@site-comps/SwitchView";
+import ImproveSection		from '@site/i18n/en/presets/ImproveSection.mdx';
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 

--- a/content/docs/std/containers/sets/unordered-set/size.mdx
+++ b/content/docs/std/containers/sets/unordered-set/size.mdx
@@ -4,15 +4,17 @@ sidebar_label:			size( )
 description:			unordered_set<...>::size() method C++ documentation
 hide_title:				true
 tags:					[size, elements, number, amount]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/size
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- size() -->
-import Method_SinceCpp11 	from './_codes/size/since-cpp11.mdx';
+import Method_SinceCpp11	from './_codes/size/since-cpp11.mdx';
 
 # std::unordered_set size() method
 

--- a/content/docs/std/containers/sets/unordered-set/swap.mdx
+++ b/content/docs/std/containers/sets/unordered-set/swap.mdx
@@ -4,16 +4,18 @@ sidebar_label:			swap( )
 description:			unordered_set<...>::swap() method C++ documentation
 hide_title:				true
 tags:					[swap, exchange, unordered_set]
+
+cppreference_origin_rel: w/cpp/container/unordered_set/swap
 ---
 
 import Columns				from "@site-comps/Columns";
-import SwitchView				from "@site-comps/SwitchView";
+import SwitchView			from "@site-comps/SwitchView";
 
 <!----------------- Codes ---------------------->
 
 <!-- swap() -->
-import Method_SinceCpp17 	from './_codes/swap/since-cpp17.mdx';
-import Method_UntilCpp17 	from './_codes/swap/until-cpp17.mdx';
+import Method_SinceCpp17	from './_codes/swap/since-cpp17.mdx';
+import Method_UntilCpp17	from './_codes/swap/until-cpp17.mdx';
 
 
 import NoexceptSpecification_SinceCpp17 from './_codes/swap/noexcept-specification/since-cpp17.mdx';

--- a/content/docs/std/containers/strings/string.mdx
+++ b/content/docs/std/containers/strings/string.mdx
@@ -5,6 +5,8 @@ sidebar_label:		string
 hide_title:			true
 description:		Summary of a std::basic_string (usage, methods, etc.) - C++ Language
 tags:				[string, container, text, char, word, phrase]
+
+cppreference_origin_rel: w/cpp/string/basic_string
 ---
 
 import ClassSummary				from "@site-comps/ClassSummary";

--- a/content/docs/std/containers/strings/string/at.mdx
+++ b/content/docs/std/containers/strings/string/at.mdx
@@ -5,6 +5,8 @@ sidebar_label:			at( )
 description:			std::string::at() method C++ documentation
 hide_title:				true
 tags:					[access, string, text, index, bounds, method]
+
+cppreference_origin_rel: w/cpp/string/basic_string/at
 ---
 
 # std::string at() method

--- a/content/docs/std/containers/strings/string/constructor.mdx
+++ b/content/docs/std/containers/strings/string/constructor.mdx
@@ -5,6 +5,8 @@ sidebar_label:		Constructors
 description:		std::string constructors C++ documentation
 hide_title:			true
 tags:				[constructor, string, method, text]
+
+cppreference_origin_rel: w/cpp/string/basic_string/basic_string
 ---
 
 # std::string constructors

--- a/content/docs/std/containers/strings/string/get_allocator.mdx
+++ b/content/docs/std/containers/strings/string/get_allocator.mdx
@@ -5,6 +5,8 @@ sidebar_label:		get_allocator( )
 description:		std::string::get_allocator C++ documentation
 hide_title:			true
 tags:				[allocator, access, string, text, method]
+
+cppreference_origin_rel: w/cpp/string/basic_string/get_allocator
 ---
 
 import Columns					from "@site-comps/Columns";

--- a/content/docs/std/containers/strings/string_view.mdx
+++ b/content/docs/std/containers/strings/string_view.mdx
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 2
 title: string_view
+
+cppreference_origin_rel: w/cpp/string/basic_string_view
 ---
 
 # String class

--- a/sidebars/docs.js
+++ b/sidebars/docs.js
@@ -239,6 +239,7 @@ module.exports = {
 									cat('Observers'),
 									'm:key_comp',
 									'm:value_comp',
+									'm:value_compare',
 
 								]),
 								docsClassCat('multimap', 'std/containers/maps/multimap', '', [
@@ -275,7 +276,7 @@ module.exports = {
 									'm:key_comp',
 									'm:value_comp',
 								]),
-								docsClassCat('unordered-map', 'std/containers/maps/unordered-map', '', [
+								docsClassCat('unordered_map', 'std/containers/maps/unordered-map', '', [
 									'constructors',
 									'destructors',
 									'op:operator_assign',
@@ -322,7 +323,7 @@ module.exports = {
 									'm:hash_function',
 									'm:key_eq'
 								]),
-								docsClassCat('unordered-multimap', 'std/containers/maps/unordered-multimap', '', [
+								docsClassCat('unordered_multimap', 'std/containers/maps/unordered-multimap', '', [
 									'constructors',
 									'destructors',
 									'op:operator_assign',
@@ -405,7 +406,7 @@ module.exports = {
 									'm:key_comp',
 									'm:value_comp',
 								]),
-								docsClassCat('unordered-set', 'std/containers/sets/unordered-set', '', [
+								docsClassCat('unordered_set', 'std/containers/sets/unordered-set', '', [
 									'constructors',
 									'destructors',
 									'op:operator_assign',
@@ -481,7 +482,7 @@ module.exports = {
 									'm:key_comp',
 									'm:value_comp',
 								]),
-								docsClassCat('unordered-multiset', 'std/containers/sets/unordered-multiset', '', [
+								docsClassCat('unordered_multiset', 'std/containers/sets/unordered-multiset', '', [
 									'constructors',
 									'destructors',
 									'op:operator_assign',

--- a/src/components/mdx/CppRefAttribution.js
+++ b/src/components/mdx/CppRefAttribution.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import Tooltip from '@site-comps/Tooltip';
+import styles from '../../css/components/CppRefAttribution.module.scss';
+
+
+export const CppRefAttribution = ({ fullUrl = "", relativeUrl = "", lang="en" }) =>
+{
+	const url = fullUrl ? fullUrl : `https://${lang}.cppreference.com/${relativeUrl || ""}`;
+
+	return (
+		<div className={styles.container}>
+			This article originates from <a href={url} target="_blank">this CppReference page</a>.
+			It was likely altered for improvements or editors' preference. Click "Edit this page" to see all
+			changes made to this document.
+			<br/>
+			<span className={styles.licenseTooltip}>
+				<Tooltip title={
+					<>
+						© cppreference.com<br/>
+						Licensed under the Creative Commons Attribution-ShareAlike Unported License v3.0.
+					</>
+				}>Hover to see the original license.</Tooltip>
+			</span>
+		</div>
+	);
+}
+
+CppRefAttribution.isMDXComponent = true;
+
+export default CppRefAttribution;

--- a/src/css/components/CppRefAttribution.module.scss
+++ b/src/css/components/CppRefAttribution.module.scss
@@ -1,0 +1,27 @@
+$dark-theme-bgc: rgba(0, 0, 0, 0.3);
+$light-theme-bgc: rgba(0, 0, 0, 0.05);
+
+.container {
+	max-width: 600px;
+	min-height: 60px;
+	padding: 15px;
+	margin: 0 auto;
+	margin-top: 20px;
+	border-radius: 10px;
+	font-size: 80%;
+	text-align: center;
+	background-color: $light-theme-bgc;
+
+	.licenseTooltip {
+		font-size: 80%;
+		text-transform: uppercase;
+	}
+}
+
+html[data-theme="dark"] {
+
+.container {
+	background-color: $dark-theme-bgc;
+}
+
+}

--- a/src/theme/DocItem/Content/index.js
+++ b/src/theme/DocItem/Content/index.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Content from '@theme-original/DocItem/Content';
+import {useDoc} from '@docusaurus/theme-common/internal';
+
+import CppRefAttribution from '@site-comps/CppRefAttribution';
+
+export default function ContentWrapper(props) {
+	const {metadata} = useDoc();
+	return (
+		<>
+			<Content {...props} />
+			{(metadata.frontMatter["cppreference_origin"] !== undefined &&
+				<CppRefAttribution fullUrl={metadata.frontMatter["cppreference_origin"]}/>)
+				||
+			(metadata.frontMatter["cppreference_origin_rel"] !== undefined &&				
+				<CppRefAttribution lang="en" relativeUrl={metadata.frontMatter["cppreference_origin_rel"]}/>)
+			}
+		</>
+	);
+}


### PR DESCRIPTION
## Description

Added attribution that looks like this:

![image](https://user-images.githubusercontent.com/6839845/189771632-d4bd4ac4-2e58-4574-ad48-858551569601.png)

It can be either added automatically using document metadata:

```md
---
cppreference_origin: https://en.cppreference.com/w/full/link/to/article
// or relative:
cppreference_origin_rel: w/relative/link/to/article
---
```

or using the `CppRefAttribution` component:

```jsx
import CppRefAttribution from "@site-comps/CppRefAttribution";

<CppRefAttribution fullUrl="https://en.cppreference.com/w/full/link/to/article" />

// or relative:

<CppRefAttribution relativeUrl="w/full/link/to/article" lang="en" />

// lang is optional
```

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` ( and remove spaces ) in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🇺🇸 Translation  
- [x] 🗑️ Chore