### PR TITLE
feat: add `Removed` tag similar to Since, Until and Deprecated

### DIFF
--- a/src/components/mdx/Versions.module.scss
+++ b/src/components/mdx/Versions.module.scss
@@ -22,6 +22,11 @@
 	background-color: rgba(gray, 0.02);
 }
 
+.markedText.removed {
+	border-color: rgba(red, 1);
+	background-color: rgba(red, 0.15);
+}
+
 
 .versionNumber {
 	background-color: rgba(black, 0.1);

--- a/src/components/mdx/Versions.tsx
+++ b/src/components/mdx/Versions.tsx
@@ -37,6 +37,14 @@ LanguageVersions.set("since-cpp17", <Translate>since C++17</Translate>);
 LanguageVersions.set("since-cpp20", <Translate>since C++20</Translate>);
 LanguageVersions.set("since-cpp23", <Translate>since C++23</Translate>);
 
+LanguageVersions.set("removed-cpp98", <Translate>removed in C++98</Translate>);
+LanguageVersions.set("removed-cpp03", <Translate>removed in C++03</Translate>);
+LanguageVersions.set("removed-cpp11", <Translate>removed in C++11</Translate>);
+LanguageVersions.set("removed-cpp14", <Translate>removed in C++14</Translate>);
+LanguageVersions.set("removed-cpp17", <Translate>removed in C++17</Translate>);
+LanguageVersions.set("removed-cpp20", <Translate>removed in C++20</Translate>);
+LanguageVersions.set("removed-cpp23", <Translate>removed in C++23</Translate>);
+
 interface MarkedTextParameters {
 	children: React.ReactNode;
 	className?: string;
@@ -80,5 +88,11 @@ export function Deprecated({children, v}: VersionProps)
 	);
 }
 
-
-
+export function Removed({children, v}: VersionProps)
+{
+	return (
+		<MarkedText className={styles.removed}>{children} 
+			&nbsp;<span className={styles.versionNumber}><small>({LanguageVersions.get(`removed-${v}`)})</small></span>
+		</MarkedText>
+	);
+}


### PR DESCRIPTION
Added a `Removed` tag, similar to the other ones like `Since`, `Until` and `Deprecated`. For now it's a little bit similar to `Until` (although it's more noticeable and vivid), but the coloring will probably be changed later.

## Type of Change

<!--- Put an `x` ( and remove spaces ) in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🇺🇸 Translation  
- [ ] 🗑️ Chore