### PR TITLE
Fix links to all the containers in the `Other` category

### DIFF
--- a/content/docs/std/containers/index.mdx
+++ b/content/docs/std/containers/index.mdx
@@ -36,7 +36,7 @@ slug: /std/containers/
 - [Multiset](sets/multiset) (`std::multiset`)
 - [Unordered multiset](sets/unordered_multiset) (`std::unordered_multiset`)
 
-### [Other](others)
+### [Other](other)
 
-- [Stack](others/stack) (`std::stack`)
-- [Span](others/span) (`std::span`)
+- [Stack](other/stack) (`std::stack`)
+- [Span](other/span) (`std::span`)

--- a/content/docs/std/index.mdx
+++ b/content/docs/std/index.mdx
@@ -59,10 +59,10 @@ We'll have to work on it.
 - [Multiset](containers/sets/multiset) (`std::multiset`)
 - [Unordered multiset](containers/sets/unordered_multiset) (`std::unordered_multiset`)
 
-### [Other](containers/others)
+### [Other](containers/other)
 
-- [Stack](containers/others/stack) (`std::stack`)
-- [Span](containers/others/span) (`std::span`)
+- [Stack](containers/other/stack) (`std::stack`)
+- [Span](containers/other/span) (`std::span`)
 
 ## [Algorithms](algo)
 

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/index.mdx
@@ -64,10 +64,10 @@ trzeba nad tym popracować
 - [Zbiór wielokrotny](containers/sets/multiset) (`std::multiset`)
 - [Zbiór nieuporządkowany wielokrotny](containers/sets/unordered_multiset) (`std::unordered_multiset`)
 
-### [Inne](containers/others)
+### [Inne](containers/other)
 
-- [Stos](containers/others/stack) (`std::stack`)
-- [Zakres](containers/others/span) (`std::span`)
+- [Stos](containers/other/stack) (`std::stack`)
+- [Zakres](containers/other/span) (`std::span`)
 
 ## [Algorytmy](algo)
 


### PR DESCRIPTION
All containers in the `other` category had set links pointing to a directory called `others`, tho that is not the case, the links were changed to point to a directory called `other`.

<!--- Put an `x` ( and remove spaces ) in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🇺🇸 Translation  
- [ ] 🗑️ Chore