### PR TITLE
ref/symbols

### DIFF
--- a/src/components/mdx/SymbolTable.js
+++ b/src/components/mdx/SymbolTable.js
@@ -34,11 +34,12 @@ export const Access = {
 };
 
 const readAccess = (props) => {
+  if (props.none) return Access.None;
 	if (props.pub	|| props.public)		return Access.Public;
 	if (props.prot	|| props.protected)		return Access.Protected;
 	if (props.priv	|| props.private)		return Access.Private;
 	else
-		return Access.None;
+		return Access.Public;
 };
 
 
@@ -60,7 +61,7 @@ export default function SymbolTable(props)
 		);
 	}
 
-	return (	
+	return (
 		displayArray(childrenArray)
 	);
 }
@@ -69,7 +70,7 @@ export default function SymbolTable(props)
 export function Symbol(props) {
 
 	const ctx = React.useContext(ClassContext);
-	
+
 	let nameElem = transformEmptyTagElem(props.name);
 
 	let desc = null;
@@ -77,14 +78,18 @@ export function Symbol(props) {
 		desc = props.desc;
 	else if (props.children)
 		desc = props.children;
-		
-	if (props.link || props.autoLink)
+
+  const hasLink = props.linkName || props.autoLink;
+  const canBeLinked = ! props.noLink && hasLink;
+
+  if (canBeLinked)
 		nameElem = <a href={props.link || `${(props.linkName || props.name)}`}>{nameElem}</a>;
 
 	const mapAccess = props => {
 		const a = readAccess(props);
 		return (<span className={a.Style}>{a.ShortName}</span>);
 	}
+
 	const mapModifier = (testValue, style, content) => {
 		switch (testValue) {
 			case true:	return <span className={styles[style]}>{content}</span>;
@@ -92,18 +97,18 @@ export function Symbol(props) {
 		}
 	}
 
-	const arr = [1, 10, 13, 15];
-
 	return (
 		<tr>
-			<td className={styles.symbolProp}>
-				{mapAccess(props)}
-				{mapModifier(props.static,		"modStatic",	"static")}
-				{mapModifier(props.constexpr,	"modConstexpr",	"constexpr")}
-				{mapModifier(props.const,		"modConst",		"const")}
-				{mapModifier(props.volatile,	"modVolatile",	"volatile")}
-				{mapModifier(props.virtual,		"modVirtual",	"virtual")}
-			</td>
+    {! props.none && (
+      <td className={styles.symbolProp}>
+        {mapAccess(props)}
+        {mapModifier(props.static,		"modStatic",	"static")}
+        {mapModifier(props.constexpr,	"modConstexpr",	"constexpr")}
+        {mapModifier(props.const,		"modConst",		"const")}
+        {mapModifier(props.volatile,	"modVolatile",	"volatile")}
+        {mapModifier(props.virtual,		"modVirtual",	"virtual")}
+      </td>
+    )}
 			<td className={styles.symbolName}>
 				{nameElem}
 			</td>

--- a/src/components/mdx/SymbolTable.module.scss
+++ b/src/components/mdx/SymbolTable.module.scss
@@ -4,9 +4,7 @@
 	border: none;
 	display: block;
 	table-layout: fixed;
-	>tr {
-		
-	}
+    border-collapse: collapse;
 
 	td:last-child {
 		width: 100%;
@@ -31,14 +29,13 @@
 	}
 }
 
-.symbolProp {	
+.symbolProp {
 	padding: 3px 10px;
 	>span {
 		display: inline-block;
 		width: 40px;
 		text-align: center;
 		font-size: 75%;
-		// border: 1px solid ;
 		border-radius: 20px;
 		&:not(:last-child) {
 			margin-right: 5px;

--- a/src/components/mdx/SymbolTable.module.scss
+++ b/src/components/mdx/SymbolTable.module.scss
@@ -6,6 +6,10 @@
 	table-layout: fixed;
     border-collapse: collapse;
 
+    tr, td, th {
+        border: none;
+    }
+
 	td:last-child {
 		width: 100%;
 	}


### PR DESCRIPTION
Remove borders, add `noLink` and `none`, make `autoLink` and `pub` the default.

### Changes in docs (`docs`)

- [ ] ✨ `improve(docs)` - e.g. added a new paragraph, example, using a better wording, adding a new document, etc.
- [ ] 🛠️ `fix(docs)` - bug fix, e.g. fix a typo, page render issue
- [ ] ❌ `BREAKING CHANGE(docs)` - e.g. removing a document/article/category that was referenced in many other places
- [ ] 🧹 `refactor(docs)` - changed a code example, e.g. replaced old code with a modern one
- [ ] 🗑️ `chore(docs)` - other changes that don't affect the docs, e.g. updating the CI/CD pipeline

### Changes in the platform (`platform`)

- [ ] ✨ `feat(platform)` - a new feature, e.g. a new MDX component, plugin, theme, etc.
- [ ] 🛠️ `fix(platform)` - bug fix, e.g. fix a typo, issue causing component to crash
- [ ] ❌ `BREAKING CHANGE(platform)` - e.g. removing a feature, changing the API, etc.
- [x] 🧹 `refactor(platform)` - code improvements, changes, e.g. unifying style, renaming internals, etc.
- [ ] 📝 `docs(platform)` - updated code documentation
- [ ] 🗑️ `chore(platform)` - other changes that don't affect the platform directly, e.g. updating the CI/CD pipeline
