### PR TITLE
fix(platform): don't render full code button if `fullCode` param is n…

### DIFF
--- a/src/components/mdx/CustomCodeBlock.tsx
+++ b/src/components/mdx/CustomCodeBlock.tsx
@@ -136,11 +136,11 @@ export default function CustomCodeBlock(props: CustomCodeBlockProps) {
       <div ref={containerRef} style={{ display: displayFullCode ? "none" : "block" }}>
         {props.children}
       </div>
-      <ControlButtons container={currentContainer}
-        onShowFullCode={handleFullCodeSwitch}
-      />
       {props.fullCode &&
         <>
+          <ControlButtons container={currentContainer}
+            onShowFullCode={handleFullCodeSwitch}
+          />
           <div ref={fullCodeRef} style={{ display: displayFullCode ? "block" : "none" }}>
             {typeof props.fullCode === "string" ?
               <CodeBlock language="cpp">


### PR DESCRIPTION
…ot present

<!--
  Thank you for contributing!
  Provide a description of your changes below and a general summary in the title.
-->

## Description

<!--- Describe your changes in detail here -->

## Type of Change

<!--- Put an `x` ( and remove spaces ) in all the boxes that apply: -->

### Changes in docs (`docs`)

- [ ] ✨ `improve(docs)` - e.g. added a new paragraph, example, using a better wording, adding a new document, etc.
- [ ] 🛠️ `fix(docs)` - bug fix, e.g. fix a typo, page render issue
- [ ] ❌ `BREAKING CHANGE(docs)` - e.g. removing a document/article/category that was referenced in many other places
- [ ] 🧹 `refactor(docs)` - changed a code example, e.g. replaced old code with a modern one
- [ ] 🗑️ `chore(docs)` - other changes that don't affect the docs, e.g. updating the CI/CD pipeline

### Changes in the platform (`platform`)

- [ ] ✨ `feat(platform)` - a new feature, e.g. a new MDX component, plugin, theme, etc.
- [x] 🛠️ `fix(platform)` - bug fix, e.g. fix a typo, issue causing component to crash
- [ ] ❌ `BREAKING CHANGE(platform)` - e.g. removing a feature, changing the API, etc.
- [ ] 🧹 `refactor(platform)` - code improvements, changes, e.g. unifying style, renaming internals, etc.
- [ ] 📝 `docs(platform)` - updated code documentation
- [ ] 🗑️ `chore(platform)` - other changes that don't affect the platform directly, e.g. updating the CI/CD pipeline
