### PR TITLE
fix: fix the link to the slides in pl course

### DIFF
--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/first-program.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/first-program.mdx
@@ -172,10 +172,10 @@ jest **akceptowalny**, jednak bardzo nieczytelny. Nie pisz kodu w ten sposób!
 :::
 
 
-Prezentacja działania wyżej stworzonego programu (w wersji angielskiej):
+Prezentacja działania wyżej stworzonego programu:
 
 <GoogleSlides
-		src="https://docs.google.com/presentation/d/e/2PACX-1vQiseFBKVq7nGeD4orMvkI0WB9BpZ6D0uf1Zwz_vguBGY_ELIKC7iZ_7lLpnXw-oAmU1If-X2LyLsji/embed"
+		src="https://docs.google.com/presentation/d/e/2PACX-1vRC5xe04Q5idpLOmu1UC54mTm-0yBIsQxeWsMCt1sITdMPJd_JGSNcmIDk-8rNGooCUzJ-FfI1GV-Kr/embed"
 		aspectRatio={960 / 500}
 		delay={500}
 		centered
@@ -202,7 +202,7 @@ Zwróć uwagę, że użyliśmy **backslash**a (`\n`), a nie **forward slash**a (
 Działanie programu po dodaniu znaków nowej linii:
 
 <GoogleSlides
-		src="https://docs.google.com/presentation/d/e/2PACX-1vRJaPRi9CcQtPZ8uMnEXkYidlwvi5OAyMoZBu49j5pTZg1t-zQB5pgXhKVhsqrH977Q9_BzN-MBjyrP/embed"
+		src="https://docs.google.com/presentation/d/e/2PACX-1vQ38nUOSerfjEUSgQkX1JZVKfTv9oVPOasubQOZOvutd7wJj_NyPesHzOdF28Txp8FxLZLLqR3xUyAT/embed"
 		aspectRatio={960 / 500}
 		delay={500}
 		centered


### PR DESCRIPTION
## Description

Fixed links to the google slides in pl article `basics/first-program`.

## Type of Change

### Changes in docs (`docs`)

- [ ] ✨ `improve(docs)` - e.g. added a new paragraph, example, using a better wording, adding a new document, etc.
- [x] 🛠️ `fix(docs)` - bug fix, e.g. fix a typo, page render issue
- [ ] ❌ `BREAKING CHANGE(docs)` - e.g. removing a document/article/category that was referenced in many other places
- [ ] 🧹 `refactor(docs)` - changed a code example, e.g. replaced old code with a modern one
- [ ] 🗑️ `chore(docs)` - other changes that don't affect the docs, e.g. updating the CI/CD pipeline

### Changes in the platform (`platform`)

- [ ] ✨ `feat(platform)` - a new feature, e.g. a new MDX component, plugin, theme, etc.
- [ ] 🛠️ `fix(platform)` - bug fix, e.g. fix a typo, issue causing component to crash
- [ ] ❌ `BREAKING CHANGE(platform)` - e.g. removing a feature, changing the API, etc.
- [ ] 🧹 `refactor(platform)` - code improvements, changes, e.g. unifying style, renaming internals, etc.
- [ ] 📝 `docs(platform)` - updated code documentation
- [ ] 🗑️ `chore(platform)` - other changes that don't affect the platform directly, e.g. updating the CI/CD pipeline
