### PR TITLE
Ref/niebloids article

### DIFF
--- a/content/docs/std/algo/_codes/niebloids/qualified-unqualified-lookup.mdx
+++ b/content/docs/std/algo/_codes/niebloids/qualified-unqualified-lookup.mdx
@@ -34,7 +34,7 @@ auto main() -> int
     // auto value = my_ns::x; // Qualified lookup
     // The above fails, because `x` is not present in my_ns namespace
 
-    // krabby_patty::patty_krabby(mr_krabs::secret_recipe);
+    // krabby_patty::patty_krabby(mr_krabs::secret_recipe); // Qualified lookup
     // The above fails, because namespaces `krabby_patty` and `mr_krabs` are not present
 
     std::print("Hello {}!", "World"); // Qualified lookup

--- a/content/docs/std/algo/niebloids.mdx
+++ b/content/docs/std/algo/niebloids.mdx
@@ -44,7 +44,7 @@ Syntatically, qualified lookup implies the use of [**scope resolution operator**
   // auto value = my_ns::x; // Qualified lookup
   // The above fails, because `x` is not present in my_ns namespace
 
-  // krabby_patty::patty_krabby(mr_krabs::secret_recipe);
+  // krabby_patty::patty_krabby(mr_krabs::secret_recipe); // Qualified lookup
   // The above fails, because namespaces `krabby_patty` and `mr_krabs` are not present
 
   std::print("Hello {}!", "World"); // Qualified lookup
@@ -64,11 +64,12 @@ Hello hello; // Unqualified lookup to Hello, which is found in global scope
   // foo(1, 2, 3); // Unqualified lookup, no scope resolution operator
   // The above fails, because `foo` is nowhere to be found
 
-  std::print(  "{}", hello.world()); // Qualified lookup to `std::print`, unqualified lookup to `hello`, which is found in upper scope
+  std::print("{}", hello.world()); // Qualified lookup to `std::print`, unqualified lookup to `hello`, which is found in upper scope
   // Unqualified searches starting from the current scope up
 
   print_me(my_ns::MyEnum::One);
   // Unqualified lookup to `print_me`, qualified lookup to my_ns::MyEnum::One
+  // This works.
   // But wait... print_me is not present in this scope, upper scope, nor global scope,
   // unqualified lookup didn't pick it up, so how does that work??
   // Is it a bug, magic, or maybe... ADL? :P

--- a/content/docs/std/algo/niebloids.mdx
+++ b/content/docs/std/algo/niebloids.mdx
@@ -21,11 +21,13 @@ in his C++14 [**range-v3**](https://github.com/ericniebler/range-v3/) library.
 
 The name was suggested by the author himself in a [poll on twitter in 2018](https://twitter.com/tcanens/status/1063723279414890496).
 
-Before getting to niebloids, we first have to have some understanding in the following topics:
+Before getting to niebloids and understanding fully what these give us, we first have to have some understanding in the following topics:
 - Unqualified lookup / Qualified lookup
 - ADL (Argument Dependent Lookup)
+- Customization Points
+- Customization Point Objects
 
-We will briefly go over them. You can skip to the last section if these topics are already familiar to you.
+We will briefly go over them. You can skip to the last section if you are already familiar with them.
 
 ## Qualified vs Unqualified Lookup
 
@@ -78,14 +80,14 @@ Hello hello; // Unqualified lookup to Hello, which is found in global scope
 
 </CustomCodeBlock>
 
-Both of these do a little bit different things, but unqualified lookup does one the other doesn't do - **A**rgument **D**ependent **L**ookup.
+Both of these do a little bit different things, but unqualified lookup has one special property, **A**rgument **D**ependent **L**ookup
+follows after it.
 
 ## Argument Dependent Lookup
 
 Argument Dependent Lookup (also sometimes reffered to as [**Koenig lookup**](https://web.archive.org/web/20180317070215/http://www.drdobbs.com/cpp/a-personal-note-about-argument-dependent/232901443))
+or ADL for short is a very advanced topic in itself, but in short, what it allows is
 calling functions from the argument's respective namespaces without qualifying them explicitly.
-or ADL for short is a very advanced topic in itself, but in short, what it allows is calling functions without qualifying them
-if they are present in the namespace of any of the arguments used.
 
 That sounds pretty complicated, but here's a simple example you've already seen and written a thousand times probably:
 ```cpp
@@ -100,7 +102,7 @@ operator<<(std::cout, "Hello, world!");
 You could even write this code yourself and see that it would compile
 (though, of course, no one would write code like this for real, it's not very practical and eliminates the convenience of overloading operators).
 
-Here's the example the previous section about lookup:
+Here's the example from the previous section about lookup:
 <CustomCodeBlock fullCode={ <FullCode_Adl/> }>
 
 ```cpp
@@ -109,12 +111,12 @@ print_me(my_ns::MyEnum::One);
 
 </CustomCodeBlock>
 
-You may be surprised it works - intuiton tells us that it shouldn't, because even tho we have a fully qualified `my_ns::MyEnum::One` which
-is resolved via qualified lookup correctly, `print_me` is not qualified and it should not be present in this scope, thus not reachable.
+You may be surprised it works - intuiton tells us that it shouldn't, because even though we have a fully qualified `my_ns::MyEnum::One` which
+is resolved via qualified lookup correctly, `print_me` is not qualified and not be present in this scope, unqualified lookup shouldn't find it and this code should not compile.
 
 And your intuition would be right.. At least if it wasn't for ADL.
 
-What ADL does is actually very simple\* - when you perform an unqualified call to a function, it looks at the types of
+What ADL does is actually very simple\* - when you perform an unqualified call to a function, ADL follows and looks at the types of
 the arguments of the functions and adds all the functions from each namespace the types of the arguments participate in to the resolution set.
 
 That is, when performing Argument Dependent Lookup on this function call:
@@ -132,7 +134,7 @@ that's what's actually important here*
 ## Unqualified lookup and ADL together
 
 Unqualified Lookup and Argument Dependent Lookup work together, one after another.
-The important rule to keep in mind about ADL - it is **not performed** in several different cases after unqualified lookup.
+The important rule to keep in mind about ADL - it is **not performed** after unqualified lookup in several different cases.
 
 One of these cases that is of interest to us is when unqualified lookup finds a declaration that is
 - neither a **function**
@@ -148,11 +150,82 @@ ADL to an object that was being looked up. An object doesn't accept any paramete
 
 Why am I talking about it? Because it's crucial for understanding Niebloids.
 
-<span class="inline-important">So once again, keep in mind - <b>ADL doesn't happen if unqualified lookup found something that is neither a function nor a function template</b></span>
+So once again, keep in mind - <span class="inline-important">ADL doesn't happen if unqualified lookup found something that is neither a function nor a function template</span>
+
+##  Customization Points
+
+One of the ways we can utilize ADL in is making so called Customization Points.
+
+You may not know about it, but you've probably used them yourself several times.
+
+`std::swap`, `std::data`, `std::begin`, `std::end` - these are all customization points.
+
+If you have a custom type which has a special, more performant or otherwise better implementation of any of these
+functions above, you can "hook" your own implementations by creating a free function with a similar interface in your type's namespace.
+
+```cpp
+namespace my_ns {
+
+struct MyAwesomeType { };
+
+auto swap(MyAwesomeType& first, MyAwesomeType& second) -> void {
+  // awesome implementation
+}
+
+}
+```
+
+The consequence of having such a design is that now the programmer has to remember about these Customization Points
+and handle them properly. What it means, is that everytime you write generic code, you have to remember to bring
+the default implementation to the current scope and call it unqualified, e.g.:
+
+```cpp
+template <typename T, typename U>
+auto awesome_function(T t, U u)
+{
+  using std::swap;
+  swap(t, u);
+}
+```
+
+This ensures that if the type has "hooked" into the customization point, it will be called, but if not, the default
+implementation will be chosen.
+
+So, remember, everytime you see code like this:
+```cpp
+std::swap(a, b);
+```
+where `a` and `b` are some generic parameters - it's probably a bug.
+
+## Customization Points are flawed, Customization Point Objects to the rescue
+
+The two problems with Customization Points are that, first of all, the programmer has to remember
+to correctly use them in generic code (doing more to achieve the correct thing) and, second of all,
+if the standard decides to add some requirements to the types of these customization points
+(for example, `Range`, for `begin`, which is pretty sensible), it would not be possible to apply them to the "hooked", custom
+implementations.
+
+These problems are solved by **C**ustomization **P**oint **O**objects, or CPOs in short.
+
+They came to C++ together with the C++20 standard ([paper which introduced them](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4381.html)).
+
+CPOs have two main goals:
+- define a central point to apply requirements to
+- define a central point to call, which will dispatch to either the "hooked" implementation or the default standard implementation
+
+The second goal is done by inhibiting (disallowing) ADL.
+
+The are currently only two ways to achieve that.
+
+One of them is to to make them function objects, as specified in the [Unqualified lookup and ADL together](#unqualified-lookup-and-adl-together) section,
+ADL doesn't happen if unqualified lookup happens to find something that is neither a **function**, nor a **function template** - a function object
+is none of those, so ADL is disabled.
+
+The other way to implement such behaviour is to use internal compiler extensions, but no known implementation does that currently.
 
 ## Niebloids
 
-Finally, we come to pinnacle of this article - niebloids.
+Finally, we come to the pinnacle of this article - niebloids.
 
 [Cppreference*](https://en.cppreference.com/w/cpp/algorithm/ranges/all_any_none_of) tells us that the key characteristics of a niebloid are:
 - Niebloids inhibit ADL
@@ -164,16 +237,9 @@ You may also stumble upon people mentioning, that <span class="inline-danger">ev
 
 ### Implementation
 
-As specified previously, niebloids inhibit (disallow) ADL, that is, when unqualified lookup happens and any of them is found, no ADL is performed.
-
-The are currently only two ways to achieve that.
-
-One of them is to to make them a function object,
-as specified in the [Unqualified lookup and ADL together](#unqualified-lookup-and-adl-together) section,
-ADL doesn't happen if unqualified lookup happens to find something that is neither a **function**, nor a **function template** - a function object
-is none of those, so ADL is disabled.
-
-The other way to implement such behaviour is to use internal compiler extensions, but no known implementation does that currently.
+You may notice, that niebloids have similar goals to CPOs. And, yeah, they are pretty much the same, except that niebloids
+don't allow for any customization points. Similarily to CPOs, they are also typically implemented using function objects,
+although that's not required.
 
 <span>**</span> One of the characteristics specified is not being able to specify explicit template arguments, it is true with
 how niebloids are currently implemented by all the major vendors, but keep in mind that it's not a planned feature of niebloids
@@ -312,4 +378,5 @@ auto const numbers = std::vector{ 1 ,2, 3, 4, 5 };
 }
 ```
 
-Then, inside, the niebloid does everything correctly. The programmer doesn't have to worry about anything.
+Then, niebloids correctly take care of everything inside. They call Customization Point Objects if neccessary, which
+take care of correct handling of customization points and all type requirements are correctly applied.


### PR DESCRIPTION
Added info about customization points and customization point objects.

## Type of Change

### Changes in docs (`docs`)

- [x] ✨ `improve(docs)` - e.g. added a new paragraph, example, using a better wording, adding a new document, etc.
- [ ] 🛠️ `fix(docs)` - bug fix, e.g. fix a typo, page render issue
- [ ] ❌ `BREAKING CHANGE(docs)` - e.g. removing a document/article/category that was referenced in many other places
- [ ] 🧹 `refactor(docs)` - changed a code example, e.g. replaced old code with a modern one
- [ ] 🗑️ `chore(docs)` - other changes that don't affect the docs, e.g. updating the CI/CD pipeline

### Changes in the platform (`platform`)

- [ ] ✨ `feat(platform)` - a new feature, e.g. a new MDX component, plugin, theme, etc.
- [ ] 🛠️ `fix(platform)` - bug fix, e.g. fix a typo, issue causing component to crash
- [ ] ❌ `BREAKING CHANGE(platform)` - e.g. removing a feature, changing the API, etc.
- [ ] 🧹 `refactor(platform)` - code improvements, changes, e.g. unifying style, renaming internals, etc.
- [ ] 📝 `docs(platform)` - updated code documentation
- [ ] 🗑️ `chore(platform)` - other changes that don't affect the platform directly, e.g. updating the CI/CD pipeline
