### PR TITLE
Change link for contributing from github page to local

### DIFF
--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -21,7 +21,7 @@ The complete standard library documentation with examples.
 
 :::caution
 It's not complete yet 😥
-Help us by [contributing](https://github.com/Cpp4You/CppLangNet/blob/main/CONTRIBUTING.md)
+Help us by [contributing](/contributing)
 :::
 
 ## [Language named requirements](named_req)


### PR DESCRIPTION

## Description

Fix link for contributing in `/docs/index` from the github page one to the local section one.

Tested once locally that link works.
## Type of Change

<!--- Put an `x` ( and remove spaces ) in all the boxes that apply: -->

### Changes in docs (`docs`)

- [x] ✨ `improve(docs)` - e.g. added a new paragraph, example, using a better wording, adding a new document, etc.
- [ ] 🛠️ `fix(docs)` - bug fix, e.g. fix a typo, page render issue
- [ ] ❌ `BREAKING CHANGE(docs)` - e.g. removing a document/article/category that was referenced in many other places
- [ ] 🧹 `refactor(docs)` - changed a code example, e.g. replaced old code with a modern one
- [ ] 🗑️ `chore(docs)` - other changes that don't affect the docs, e.g. updating the CI/CD pipeline

### Changes in the platform (`platform`)

- [ ] ✨ `feat(platform)` - a new feature, e.g. a new MDX component, plugin, theme, etc.
- [ ] 🛠️ `fix(platform)` - bug fix, e.g. fix a typo, issue causing component to crash
- [ ] ❌ `BREAKING CHANGE(platform)` - e.g. removing a feature, changing the API, etc.
- [ ] 🧹 `refactor(platform)` - code improvements, changes, e.g. unifying style, renaming internals, etc.
- [ ] 📝 `docs(platform)` - updated code documentation
- [ ] 🗑️ `chore(platform)` - other changes that don't affect the platform directly, e.g. updating the CI/CD pipeline
