### PR TITLE
Fix array concatenation example in the documentation

### DIFF
--- a/content/docs/std/containers/arrays/_codes/array/main-page/examples/further/concat-two-arrays.mdx
+++ b/content/docs/std/containers/arrays/_codes/array/main-page/examples/further/concat-two-arrays.mdx
@@ -14,7 +14,7 @@ auto concat(
 	std::array<T, N1 + N2> result;
 
 	rg::copy(lhs, result.begin());
-	rg::copy(rhs, result.begin() + rhs.size());
+	rg::copy(rhs, result.begin() + lhs.size());
 
 	return result;
 }

--- a/content/docs/std/containers/arrays/_codes/array/main-page/examples/further/concat-two-arrays.mdx
+++ b/content/docs/std/containers/arrays/_codes/array/main-page/examples/further/concat-two-arrays.mdx
@@ -14,7 +14,7 @@ auto concat(
 	std::array<T, N1 + N2> result;
 
 	rg::copy(lhs, result.begin());
-	rg::copy(rhs, result.begin() + lhs.size());
+	rg::copy_backward(rhs, result.end());
 
 	return result;
 }


### PR DESCRIPTION
As mentioned in https://github.com/Cpp4You/CppLangNet/discussions/243 by @yval1,
the array concatenation example is buggy, because we're copying the wrong amount of elements second time.

Initially I simply gave into the suggestion of simply correcting the mistake and using proper
source container, but after a little bit of thought I changed `copy` to `copy_backward` which doesn't leave much more error for bugs and is more descriptive.