### PR TITLE
feat: completion frontmatter param

### DIFF
--- a/content/contributing/writing-guide/improving.mdx
+++ b/content/contributing/writing-guide/improving.mdx
@@ -1,11 +1,8 @@
 ---
-sidebar_label:	"Improving existing documents"
-title:			"Improving existing documents"
+sidebar_label:  "Improving existing documents"
+title:          "Improving existing documents"
+completion:     false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 ## Correcting grammar and other simple problems
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -3,11 +3,8 @@ sidebar_position: 1
 title: Summary
 slug: /
 hide_title: true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # C++ Documentation
 

--- a/content/docs/std/containers/lists/forward_list.mdx
+++ b/content/docs/std/containers/lists/forward_list.mdx
@@ -5,6 +5,7 @@ description:              Summary of a std::forward_list (usage, methods, etc.) 
 tags:                     [list, forward_list, forward]
 defined_in_headers:       "<forward_list>"
 cppreference_origin_rel:  w/cpp/container/forward_list
+completion: false
 ---
 
 {/* Theme components */}
@@ -19,7 +20,6 @@ import { Since, Until, Removed }  from "@site-comps/Versions";
 import HiddenHeading              from "@site-comps/HiddenHeading";
 
 {/* Presets */}
-import NotFinished                from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection             from '@site/i18n/en/presets/ImproveSection.mdx';
 
 {/* Codes */}
@@ -29,8 +29,6 @@ import OverviewDetailedRegular    from "./forward_list/_codes/main-page/overview
 import OverviewDetailedPmr        from "./forward_list/_codes/main-page/overview/overview-detailed-pmr.mdx";
 
 import DeductionGuides            from "./forward_list/_codes/main-page/deduction-guides.mdx";
-
-<NotFinished />
 
 <HiddenHeading>
   ## Overview

--- a/content/docs/std/containers/other/span.mdx
+++ b/content/docs/std/containers/other/span.mdx
@@ -7,13 +7,13 @@ tags:				[span, container, view, array, contiguous]
 hide_title:			true
 
 cppreference_origin_rel: w/cpp/container/span
+completion: false
 ---
 
 import ClassSummary					from "@site-comps/ClassSummary";
 import SymbolTable, { Symbol, CodeSymbol }		from "@site-comps/SymbolTable";
 import Columns						from "@site-comps/Columns";
 import Image						from "@site-comps/Image";
-import NotFinished					from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection				from "@site/i18n/en/presets/ImproveSection.mdx";
 import VersionTabs					from "@site-comps/VersionTabs";
 import Tabs							from "@theme/Tabs";
@@ -38,8 +38,6 @@ import HelperTemplate_EnableView from "./span/_codes/main-page/helper-templates/
 
 {/* Template parameter table */}
 import TemplateParameterTable from "./span/_codes/shared/template-parameters-table.mdx";
-
-<NotFinished />
 
 # Span class reference
 

--- a/content/docs/std/containers/other/stack.mdx
+++ b/content/docs/std/containers/other/stack.mdx
@@ -7,12 +7,12 @@ description:		Summary of a std::stack (usage, methods, etc.) - C++ Language
 tags:				[stack, adapter, lifo]
 
 cppreference_origin_rel: w/cpp/container/stack
+completion: false
 ---
 
 import ClassSummary				from "@site-comps/ClassSummary";
 import SymbolTable, { Symbol }	from "@site-comps/SymbolTable";
 import Columns					from "@site-comps/Columns";
-import NotFinished				from "@site/i18n/en/presets/NotFinished.mdx";
 import Tabs						from "@theme/Tabs";
 import TabItem					from "@theme/TabItem";
 
@@ -34,8 +34,6 @@ import MemberObjects from "./stack/_codes/shared/member-objects.mdx";
 
 {/* Deduction Guides */}
 import DeductionGuides				from "./stack/_codes/main-page/deduction-guides.mdx";
-
-<NotFinished />
 
 # Stack class reference
 

--- a/content/docs/std/containers/queues/deque.mdx
+++ b/content/docs/std/containers/queues/deque.mdx
@@ -7,6 +7,7 @@ description:		Summary of a std::deque (usage, methods, etc.) - C++ Language
 tags:				[deque, queue, double]
 
 cppreference_origin_rel: w/cpp/container/deque
+completion: false
 ---
 
 import Tabs                       from "@theme/Tabs";
@@ -16,10 +17,6 @@ import SymbolTable, { Symbol }    from "@site-comps/SymbolTable";
 import Columns                    from "@site-comps/Columns";
 import { Since, Until, Removed }  from "@site-comps/Versions";
 import CustomCodeBlock            from "@site-comps/CustomCodeBlock";
-
-{/* Presets */}
-
-import NotFinished                from "@site/i18n/en/presets/NotFinished.mdx";
 
 {/* Codes */}
 
@@ -37,8 +34,6 @@ import DeductionGuides				from "./deque/_codes/main-page/deduction-guides.mdx";
 
 import TemplateParamTExplanation from "./deque/_codes/main-page/template-parameters/t.mdx";
 import TemplateParamAllocatorExplanation from "./deque/_codes/main-page/template-parameters/allocator.mdx";
-
-<NotFinished />
 
 ## Overview
 

--- a/content/docs/std/containers/queues/priority_queue.mdx
+++ b/content/docs/std/containers/queues/priority_queue.mdx
@@ -7,13 +7,13 @@ description:		Summary of a std::priority_queue (usage, methods, etc.) - C++ Lang
 tags:				[priority_queue, queue, priority, order, comparator]
 
 cppreference_origin_rel: w/cpp/container/priority_queue
+completion: false
 ---
 
 import ClassSummary				from "@site-comps/ClassSummary";
 import CustomCodeBlock			from "@site-comps/CustomCodeBlock";
 import SymbolTable, { Symbol }	from "@site-comps/SymbolTable";
 import Columns					from "@site-comps/Columns";
-import NotFinished				from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection			from "@site/i18n/en/presets/ImproveSection.mdx";
 import Tabs						from "@theme/Tabs";
 import TabItem					from "@theme/TabItem";
@@ -34,8 +34,6 @@ import DeductionGuides				from "./priority_queue/_codes/main-page/deduction-guid
 import TemplateParamContainerExplanation from "./priority_queue/_codes/main-page/template-parameters/container.mdx";
 import TemplateParamTExplanation from "./priority_queue/_codes/main-page/template-parameters/t.mdx";
 import TemplateParamCompareExplanation from "./priority_queue/_codes/main-page/template-parameters/compare.mdx";
-
-<NotFinished />
 
 ## Overview
 

--- a/content/docs/std/containers/queues/queue.mdx
+++ b/content/docs/std/containers/queues/queue.mdx
@@ -7,6 +7,7 @@ description:		Summary of a std::queue (usage, methods, etc.) - C++ Language
 tags:				[queue, adapter, fifo]
 
 cppreference_origin_rel: w/cpp/container/queue
+completion: false
 ---
 
 import Tabs                     from "@theme/Tabs";
@@ -15,10 +16,6 @@ import ClassSummary             from "@site-comps/ClassSummary";
 import SymbolTable, { Symbol }  from "@site-comps/SymbolTable";
 import Columns                  from "@site-comps/Columns";
 import CustomCodeBlock          from "@site-comps/CustomCodeBlock";
-
-{/* Presets */}
-
-import NotFinished              from "@site/i18n/en/presets/NotFinished.mdx";
 
 {/* Codes */}
 
@@ -35,7 +32,6 @@ import DeductionGuides				from "./queue/_codes/main-page/deduction-guides.mdx";
 import TemplateParamContainerExplanation from "./queue/_codes/main-page/template-parameters/container.mdx";
 import TemplateParamTExplanation from "./queue/_codes/main-page/template-parameters/t.mdx";
 
-<NotFinished />
 
 ## Overview
 

--- a/content/docs/std/containers/strings/string.mdx
+++ b/content/docs/std/containers/strings/string.mdx
@@ -22,7 +22,6 @@ import { Since, Until, Removed }  from "@site-comps/Versions";
 import HiddenHeading              from "@site-comps/HiddenHeading";
 
 {/* Presets */}
-import NotFinished                from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection             from "@site/i18n/en/presets/ImproveSection.mdx";
 
 {/* Codes */}

--- a/content/docs/std/containers/strings/string_view.mdx
+++ b/content/docs/std/containers/strings/string_view.mdx
@@ -23,7 +23,6 @@ import { Since, Until, Removed }  from "@site-comps/Versions";
 import HiddenHeading              from "@site-comps/HiddenHeading";
 
 {/* Presets */}
-import NotFinished                from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection             from "@site/i18n/en/presets/ImproveSection.mdx";
 
 {/* Codes */}

--- a/content/docs/std/index.mdx
+++ b/content/docs/std/index.mdx
@@ -3,11 +3,8 @@ sidebar_position:	1
 title:				The standard library
 hide_title:			true
 slug: /std/
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # The standard library
 

--- a/content/docs/std/math/numeric_algorithms.mdx
+++ b/content/docs/std/math/numeric_algorithms.mdx
@@ -11,8 +11,7 @@ import ClassSummary				from "@site-comps/ClassSummary";
 import SymbolTable, { Symbol }	from "@site-comps/SymbolTable";
 import Columns					from "@site-comps/Columns";
 import VersionTabs				from "@site-comps/VersionTabs";
-import NotFinished				from "@site/i18n/en/presets/NotFinished.mdx";
-import ImproveSection			from "@site/i18n/en/presets/ImproveSection.mdx";
+
 import Tabs						from "@theme/Tabs";
 import TabItem					from "@theme/TabItem";
 

--- a/content/learn/compilation/compilation-process.mdx
+++ b/content/learn/compilation/compilation-process.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 2
+completion: false
 ---
 
 # Compilation process
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/content/learn/compilation/flags/fast-math.mdx
+++ b/content/learn/compilation/flags/fast-math.mdx
@@ -4,11 +4,8 @@ sidebar_label:	"Fast math"
 title:			"Fast math - Compilation flag"
 description:	"Fast math compilation flag guide for C++ language"
 hide_title:		true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Fast math
 

--- a/content/learn/compilation/flags/lang-standard.mdx
+++ b/content/learn/compilation/flags/lang-standard.mdx
@@ -4,11 +4,8 @@ sidebar_label:	"Language standard"
 title:			"Language standard - Compilation flag"
 description:	"Language standard compilation flag guide for C++ language"
 hide_title:		true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Language standard
 

--- a/content/learn/compilation/flags/visibility.mdx
+++ b/content/learn/compilation/flags/visibility.mdx
@@ -4,11 +4,8 @@ sidebar_label:	"Symbol visibility"
 title:			"Symbol visibility - Compilation flag"
 description:	"Symbol visibility compilation flag guide for C++ language"
 hide_title:		true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Symbol visibility
 

--- a/content/learn/compilation/linker.mdx
+++ b/content/learn/compilation/linker.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 4
+completion: false
 ---
 
 # Linker
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/content/learn/compilation/multiple-files.mdx
+++ b/content/learn/compilation/multiple-files.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 5
+completion: false
 ---
 
 # Multiple files
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/content/learn/compilation/preprocessor.mdx
+++ b/content/learn/compilation/preprocessor.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 3
+completion: false
 ---
 
 # Preprocessor
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/content/learn/compilation/target-types.mdx
+++ b/content/learn/compilation/target-types.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 6
+completion: false
 ---
 
 # Target types
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/content/learn/compilation/what-is-compiler.mdx
+++ b/content/learn/compilation/what-is-compiler.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 1
+completion: false
 ---
 
 # What is a compiler
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/content/learn/course/advanced/classes/copy-constructor.mdx
+++ b/content/learn/course/advanced/classes/copy-constructor.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"2. Copy constructors 🚧"
 title:				"Copy constructors"
 description:		"Lesson: using copy constructors in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Copy constructors
 

--- a/content/learn/course/advanced/classes/default-constructors.mdx
+++ b/content/learn/course/advanced/classes/default-constructors.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"1. Default constructors 🚧"
 title:				"Default constructors"
 description:		"Lesson: using default constructors in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Default constructors
 

--- a/content/learn/course/advanced/classes/move-constructors.mdx
+++ b/content/learn/course/advanced/classes/move-constructors.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"3. Move constructors 🚧"
 title:				"Move constructors"
 description:		"Lesson: using move constructors in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Move constructors
 

--- a/content/learn/course/advanced/constants.mdx
+++ b/content/learn/course/advanced/constants.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"1. Constants (II) 🚧"
 title:				"Constants (II)"
 description:		"Lesson: constants (II) in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Constants
 

--- a/content/learn/course/advanced/exceptions/in-constructor.mdx
+++ b/content/learn/course/advanced/exceptions/in-constructor.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"1. In constructor 🚧"
 title:				"Exceptions in constructors"
 description:		"Lesson: handling exceptions in constructor in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Exceptions in constructors
 

--- a/content/learn/course/advanced/exceptions/noexcept.mdx
+++ b/content/learn/course/advanced/exceptions/noexcept.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"2. noexcept 🚧"
 title:				"Using noexcept"
 description:		"Lesson: using noexcept specifier in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Using `noexcept` specifier
 

--- a/content/learn/course/advanced/iterators.mdx
+++ b/content/learn/course/advanced/iterators.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"6. Iterators (I) 🚧"
 title:				"Iterators (I)"
 description:		"Lesson: using iterators (I) in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Iterators
 

--- a/content/learn/course/advanced/lambdas.mdx
+++ b/content/learn/course/advanced/lambdas.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"3. Lambdas (II) 🚧"
 title:				"Lambdas (II)"
 description:		"Lesson: advanced lambdas (II) in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished		from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Lambdas
 

--- a/content/learn/course/advanced/memory/new-and-delete.mdx
+++ b/content/learn/course/advanced/memory/new-and-delete.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"3. new, delete 🚧"
 title:				"new and delete operators"
 description:		"Lesson: correct usage of new and delete operators in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # New and delete operators
 

--- a/content/learn/course/advanced/memory/pointers.mdx
+++ b/content/learn/course/advanced/memory/pointers.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"2. Pointers (II) 🚧"
 title:				"Pointers (II)"
 description:		"Lesson: pointers (II) in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Pointers
 

--- a/content/learn/course/advanced/memory/raw-arrays.mdx
+++ b/content/learn/course/advanced/memory/raw-arrays.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"1. Raw arrays 🚧"
 title:				"Raw arrays"
 description:		"Lesson: raw arrays (Type[N]) in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Raw arrays
 

--- a/content/learn/course/advanced/preprocessor.mdx
+++ b/content/learn/course/advanced/preprocessor.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"8. Preprocessor (II) 🚧"
 title:				"Preprocessor (II)"
 description:		"Lesson: preprocessor (II) in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Preprocessor
 

--- a/content/learn/course/advanced/references.mdx
+++ b/content/learn/course/advanced/references.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"7. References (III) 🚧"
 title:				"References (III)"
 description:		"Lesson: References (III) in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # References
 

--- a/content/learn/course/advanced/templates/aliases.mdx
+++ b/content/learn/course/advanced/templates/aliases.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"3. Aliases 🚧"
 title:				"Templated aliases"
 description:		"Lesson: creating templated aliases in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Templated aliases
 

--- a/content/learn/course/advanced/templates/classes.mdx
+++ b/content/learn/course/advanced/templates/classes.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"2. Classes 🚧"
 title:				"Class templates"
 description:		"Lesson: creating class templates in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Class templates
 

--- a/content/learn/course/advanced/templates/fold-expr.mdx
+++ b/content/learn/course/advanced/templates/fold-expr.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"5. Fold expressions 🚧"
 title:				"Fold expressions"
 description:		"Lesson: using fold expressions in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Fold expressions
 

--- a/content/learn/course/advanced/templates/functions.mdx
+++ b/content/learn/course/advanced/templates/functions.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"1. Functions 🚧"
 title:				"Function templates"
 description:		"Lesson: creating function templates in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Function templates
 

--- a/content/learn/course/advanced/templates/variables.mdx
+++ b/content/learn/course/advanced/templates/variables.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"4. Variables 🚧"
 title:				"Variable templates"
 description:		"Lesson: creating variable templates in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Variable templates
 

--- a/content/learn/course/basics/aliases.mdx
+++ b/content/learn/course/basics/aliases.mdx
@@ -1,13 +1,10 @@
 ---
-title:				"Aliases"
-description:		"Lesson: basics of aliases (\"using\" keyword) in C++ language"
-tags:				[alias, using, typedef]
-hide_title:			true
+title:        "Aliases"
+description:  "Lesson: basics of aliases (\"using\" keyword) in C++ language"
+tags:         [alias, using, typedef]
+hide_title:   true
+completion:   false
 ---
-
-import NotFinished from '@site/i18n/en/presets/NotFinished.mdx';
-
-<NotFinished/>
 
 # Aliases
 

--- a/content/learn/course/basics/arrays/algorithms.mdx
+++ b/content/learn/course/basics/arrays/algorithms.mdx
@@ -3,6 +3,7 @@ sidebar_label:		"4. Using algorithms"
 title:				Using algorithms
 description:		"Lesson: using algorithms on arrays in C++"
 hide_title:			true
+completion: false
 ---
 
 {/* Components */}
@@ -11,7 +12,6 @@ import Image			from "@site-comps/Image";
 import Columns			from "@site-comps/Columns";
 
 {/* Presets */}
-import NotFinished		from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
 
 {/* Codes */}
@@ -20,8 +20,6 @@ import AlgoIntroExampleUntilCpp20	from "./_codes/algo-intro-example-until-cpp20.
 
 import AlgosOverviewCpp20			from "./_codes/algos-overview-cpp20.mdx";
 import AlgosOverviewUntilCpp20		from "./_codes/algos-overview-until-cpp20.mdx";
-
-<NotFinished />
 
 # Using algorithms
 

--- a/content/learn/course/basics/arrays/c-style-arrays.mdx
+++ b/content/learn/course/basics/arrays/c-style-arrays.mdx
@@ -11,7 +11,6 @@ import Columns			from "@site-comps/Columns";
 import FullCode			from "@site-comps/FullCode";
 
 {/* Presets */}
-import NotFinished		from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
 
 # C-style arrays

--- a/content/learn/course/basics/arrays/dynamic-arrays.mdx
+++ b/content/learn/course/basics/arrays/dynamic-arrays.mdx
@@ -12,7 +12,6 @@ import Columns			from "@site-comps/Columns";
 import CustomCodeBlock			from "@site-comps/CustomCodeBlock";
 
 {/* Presets */}
-import NotFinished		from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
 
 {/* Codes */}

--- a/content/learn/course/basics/arrays/dynamic-arrays/common-problems.mdx
+++ b/content/learn/course/basics/arrays/dynamic-arrays/common-problems.mdx
@@ -3,13 +3,11 @@ title:				"Dynamic arrays » Common problems"
 description:		"Lesson: common problems with dynamic arrays in C++"
 tags:				[vector, problems, arrays, dynamic]
 hide_title:			true
+completion: false
 ---
 
 {/* Presets */}
-import NotFinished		from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-
-<NotFinished />
 
 # Dynamic arrays » Common problems
 

--- a/content/learn/course/basics/arrays/exercises.mdx
+++ b/content/learn/course/basics/arrays/exercises.mdx
@@ -3,10 +3,7 @@ sidebar_position:	3
 title:				Exercises
 description:		"Lesson: exercises using vector in C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Exercises

--- a/content/learn/course/basics/arrays/fixed-size-arrays.mdx
+++ b/content/learn/course/basics/arrays/fixed-size-arrays.mdx
@@ -15,7 +15,6 @@ import Columns			from "@site-comps/Columns";
 import FullCode			from "@site-comps/FullCode";
 
 {/* Presets */}
-import NotFinished		from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
 
 {/* Codes */}

--- a/content/learn/course/basics/arrays/fixed-size-arrays/common-problems.mdx
+++ b/content/learn/course/basics/arrays/fixed-size-arrays/common-problems.mdx
@@ -3,13 +3,11 @@ title:			"Fixed-size arrays » Common problems"
 description:	"Lesson: common problems with fixed-size arrays in C++"
 tags:			[array, problems, arrays, fixed-size]
 hide_title:		true
+completion: false
 ---
 
 {/* Presets */}
-import NotFinished		from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-
-<NotFinished />
 
 # Fixed-size arrays » Common problems
 

--- a/content/learn/course/basics/arrays/introduction.mdx
+++ b/content/learn/course/basics/arrays/introduction.mdx
@@ -11,7 +11,6 @@ import Image			from "@site-comps/Image";
 import Tooltip			from "@site-comps/Tooltip";
 
 {/* Presets */}
-import NotFinished		from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
 
 {/* Codes */}

--- a/content/learn/course/basics/articles/console.mdx
+++ b/content/learn/course/basics/articles/console.mdx
@@ -4,11 +4,7 @@ sidebar_label:		🖥 Console
 title:				Console
 tags:				[console, os-dependent]
 hide_title:			true
+completion: false
 ---
-
-{/* Presets */}
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Console

--- a/content/learn/course/basics/conditions/common-problems.mdx
+++ b/content/learn/course/basics/conditions/common-problems.mdx
@@ -3,12 +3,7 @@ title:				"Conditions » Common problems"
 description:		"Lesson: common problems with conditions in C++"
 tags:				[condition, if, else, else-if, compound, bool, boolean, bugs, problems]
 hide_title:			true
+completion: false
 ---
-
-{/* Presets */}
-import NotFinished		from "@site/i18n/en/presets/NotFinished.mdx";
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-
-<NotFinished />
 
 # Conditions » Common problems

--- a/content/learn/course/basics/conditions/compound.mdx
+++ b/content/learn/course/basics/conditions/compound.mdx
@@ -9,9 +9,6 @@ hide_title:			true
 import Tabs			from "@theme/Tabs";
 import TabItem		from "@theme/TabItem";
 
-{/* Presets */}
-import NotFinished	from "@site/i18n/en/presets/NotFinished.mdx";
-
 
 # Compound Conditions
 

--- a/content/learn/course/basics/conditions/intro.mdx
+++ b/content/learn/course/basics/conditions/intro.mdx
@@ -9,9 +9,6 @@ hide_title:			true
 import Tabs			from "@theme/Tabs";
 import TabItem		from "@theme/TabItem";
 
-{/* Presets */}
-import NotFinished	from "@site/i18n/en/presets/NotFinished.mdx";
-
 # Introduction to Conditions
 
 So far, we've been creating programs that worked the same way every time.

--- a/content/learn/course/basics/example-programs/advanced-calc.mdx
+++ b/content/learn/course/basics/example-programs/advanced-calc.mdx
@@ -5,11 +5,8 @@ title:				Advanced calculator
 description:		"Example program: an advanced calculator in C++ language"
 hide_title:			true
 tags: [example, math, advanced, calculator, input, output]
+completion: false
 ---
-
-import NotFinished from '@site/i18n/en/presets/NotFinished.mdx';
-
-<NotFinished/>
 
 # Advanced calculator
 

--- a/content/learn/course/basics/example-programs/combat-arena.mdx
+++ b/content/learn/course/basics/example-programs/combat-arena.mdx
@@ -5,9 +5,5 @@ title:				Combat arena
 description:		"Example program: a combat arena (game) in C++ language"
 hide_title:			true
 tags: [example, game, structure, array, vector]
+completion: false
 ---
-
-import NotFinished		from '@site/i18n/en/presets/NotFinished.mdx';
-import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-
-<NotFinished/>

--- a/content/learn/course/basics/example-programs/simple-calc.mdx
+++ b/content/learn/course/basics/example-programs/simple-calc.mdx
@@ -5,12 +5,10 @@ title:				Simple calculator
 description:		"Example program: a simple calculator in C++ language"
 hide_title:			true
 tags: [example, math, simple, calculator, input, output]
+completion: false
 ---
 
-import NotFinished		from '@site/i18n/en/presets/NotFinished.mdx';
 import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-
-<NotFinished/>
 
 # Simple calculator
 

--- a/content/learn/course/basics/first-program.mdx
+++ b/content/learn/course/basics/first-program.mdx
@@ -14,9 +14,6 @@ import GoogleSlides     from '@site-comps/GoogleSlides';
 import Image            from '@site-comps/Image';
 import Tooltip          from '@site-comps/Tooltip';
 
-{/* Presets */}
-import NotFinished  from '@site/i18n/en/presets/NotFinished.mdx';
-
 {/* Inspections */}
 import CodeBlockContentInspection from "./_inspections/first-program/code-block-content.tsx";
 import InstructionOrderInspection from "./_inspections/first-program/instruction-order.tsx";

--- a/content/learn/course/basics/first-program/common-problems.mdx
+++ b/content/learn/course/basics/first-program/common-problems.mdx
@@ -6,7 +6,6 @@ import Columns		from '@site-comps/Columns';
 import GoogleSlides	from '@site-comps/GoogleSlides';
 import Image		from '@site-comps/Image';
 import Tooltip		from '@site-comps/Tooltip';
-import NotFinished	from '@site/i18n/en/presets/NotFinished.mdx';
 
 import Tabs			from '@theme/Tabs';
 import TabItem		from '@theme/TabItem';

--- a/content/learn/course/basics/functions/functions.mdx
+++ b/content/learn/course/basics/functions/functions.mdx
@@ -4,10 +4,10 @@ description:		"Lesson: function basics in C++"
 tags:				[function, call]
 hide_title:			true
 pagination_next:	"course/basics/functions/examples"
+completion: false
 ---
 
 {/* Presets */}
-import NotFinished				from '@site/i18n/en/presets/NotFinished.mdx';
 import ImproveSection			from '@site/i18n/en/presets/ImproveSection.mdx';
 
 {/* Components */}
@@ -25,8 +25,6 @@ import Code_TopExampleWith					from "./_codes/functions/top-example-with.mdx";
 import Code_ExampleReuse					from "./_codes/functions/example-reuse.mdx";
 import Code_ExampleReuseWithParam			from "./_codes/functions/example-reuse-with-param.mdx";
 import Code_ExampleReuseWithParams			from "./_codes/functions/example-reuse-with-params.mdx";
-
-<NotFinished/>
 
 # Functions
 

--- a/content/learn/course/basics/inheritance.mdx
+++ b/content/learn/course/basics/inheritance.mdx
@@ -1,17 +1,15 @@
 ---
 title:			"Inheritance"
 description:	"Lesson: inheritance basics in C++"
+completion: false
 ---
 
 # Inheritance
 
 import CustomCodeBlock from "@site-comps/CustomCodeBlock";
-import NotFinished from '@site/i18n/en/presets/NotFinished.mdx';
 import FullCode_DerivedStructs from "./_codes/inheritance/full-code-step-derived-structs.mdx"
 import FullCode_DerivedStructsUsage from "./_codes/inheritance/full-code-step-derived-structs-usage.mdx"
 import FullCode_DerivedStructsMethods from "./_codes/inheritance/full-code-step-derived-structs-methods.mdx"
-
-<NotFinished/>
 
 In this lesson you will learn how to use inheritance in order to share properties and characteristic from other classes
 by building class hierarchy and prevent redundant code. 

--- a/content/learn/course/basics/loops.mdx
+++ b/content/learn/course/basics/loops.mdx
@@ -17,7 +17,6 @@ import Columns          from "@site-comps/Columns";
 
 {/* Presets */}
 import ImproveSection   from '@site/i18n/en/presets/ImproveSection.mdx';
-import NotFinished      from '@site/i18n/en/presets/NotFinished.mdx';
 
 {/* Code */}
 import FullCode_PrintNumbersRangeBasedFor from './_codes/loops/print-numbers-range-based-for-full.mdx';

--- a/content/learn/course/basics/methods/methods.mdx
+++ b/content/learn/course/basics/methods/methods.mdx
@@ -12,7 +12,6 @@ import Tabs				from '@theme/Tabs';
 import TabItem			from '@theme/TabItem';
 
 {/*  Presets */}
-import NotFinished		from '@site/i18n/en/presets/NotFinished.mdx';
 import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
 
 {/* Codes */}

--- a/content/learn/course/basics/methods/special-methods.mdx
+++ b/content/learn/course/basics/methods/special-methods.mdx
@@ -13,7 +13,6 @@ import Tabs				from '@theme/Tabs';
 import TabItem			from '@theme/TabItem';
 
 {/*  Presets */}
-import NotFinished		from '@site/i18n/en/presets/NotFinished.mdx';
 import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
 
 {/* Codes */}

--- a/content/learn/course/basics/namespaces.mdx
+++ b/content/learn/course/basics/namespaces.mdx
@@ -3,10 +3,7 @@ title:				"Namespaces"
 description:		"Lesson: basics of namespaces in C++ language"
 tags:				[namespace, scope, visibility]
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from '@site/i18n/en/presets/NotFinished.mdx';
-
-<NotFinished/>
 
 # Namespaces

--- a/content/learn/course/basics/structures.mdx
+++ b/content/learn/course/basics/structures.mdx
@@ -13,7 +13,6 @@ import Image			from "@site-comps/Image";
 
 {/* Presets */}
 import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-import NotFinished		from '@site/i18n/en/presets/NotFinished.mdx';
 
 # Structures
 

--- a/content/learn/course/basics/variables/common-problems.mdx
+++ b/content/learn/course/basics/variables/common-problems.mdx
@@ -3,13 +3,11 @@ title:			"Variables » Common problems"
 description:	"Lesson: common problems with variables in C++"
 tags:			[variable, problems]
 hide_title:		true
+completion: false
 ---
 
 {/* Presets */}
-import NotFinished		from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-
-<NotFinished />
 
 # Variables » Common problems
 

--- a/content/learn/course/basics/variables/examples.mdx
+++ b/content/learn/course/basics/variables/examples.mdx
@@ -3,13 +3,11 @@ title:			"Variables » More examples"
 description:	"Lesson: more examples of variables usage in C++"
 tags:			[variable, examples]
 hide_title:		true
+completion: false
 ---
 
 {/* Presets */}
-import NotFinished		from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-
-<NotFinished />
 
 # Variables » More examples
 

--- a/content/learn/course/basics/variables/exercises.mdx
+++ b/content/learn/course/basics/variables/exercises.mdx
@@ -3,13 +3,11 @@ title:			"Variables » Exercises"
 description:	"Lesson: exercises for variables lesson in C++"
 tags:			[variable, exercises]
 hide_title:		true
+completion: false
 ---
 
 {/* Presets */}
-import NotFinished		from "@site/i18n/en/presets/NotFinished.mdx";
 import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-
-<NotFinished />
 
 # Variables » Exercises
 

--- a/content/learn/course/basics/variables/strings/common-problems.mdx
+++ b/content/learn/course/basics/variables/strings/common-problems.mdx
@@ -8,7 +8,6 @@ import Columns		from '@site-comps/Columns';
 import GoogleSlides	from '@site-comps/GoogleSlides';
 import Image		from '@site-comps/Image';
 import Tooltip		from '@site-comps/Tooltip';
-import NotFinished	from '@site/i18n/en/presets/NotFinished.mdx';
 
 import Tabs			from '@theme/Tabs';
 import TabItem		from '@theme/TabItem';

--- a/content/learn/course/intermediate/classes/class-namespaces.mdx
+++ b/content/learn/course/intermediate/classes/class-namespaces.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"7. Class namespaces 🚧"
 title:				"Class namespaces"
 description:		"Lesson: class namespaces in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Class namespaces
 

--- a/content/learn/course/intermediate/classes/const-methods.mdx
+++ b/content/learn/course/intermediate/classes/const-methods.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"4. Const methods 🚧"
 title:				"Const methods"
 description:		"Lesson: methods of const objects in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Methods of const objects
 

--- a/content/learn/course/intermediate/classes/constructors.mdx
+++ b/content/learn/course/intermediate/classes/constructors.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"2. Constructors (I) 🚧"
 title:				"Constructors (I)"
 description:		"Lesson: class constructors (I) in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Constructors
 

--- a/content/learn/course/intermediate/classes/destructors.mdx
+++ b/content/learn/course/intermediate/classes/destructors.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"3. Destructors 🚧"
 title:				"Destructors"
 description:		"Lesson: class destructors in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Destructors
 

--- a/content/learn/course/intermediate/classes/intro.mdx
+++ b/content/learn/course/intermediate/classes/intro.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"1. Introduction 🚧"
 title:				"Introduction to classes"
 description:		"Lesson: introduction to classes in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Introduction to classes
 

--- a/content/learn/course/intermediate/classes/nested-classes.mdx
+++ b/content/learn/course/intermediate/classes/nested-classes.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"6. Nested classes 🚧"
 title:				"Nested classes"
 description:		"Lesson: nesting classes in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Nested classes
 

--- a/content/learn/course/intermediate/classes/static-methods.mdx
+++ b/content/learn/course/intermediate/classes/static-methods.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"5. Static methods 🚧"
 title:				"Static methods"
 description:		"Lesson: static methods in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Static methods
 

--- a/content/learn/course/intermediate/const-correctness.mdx
+++ b/content/learn/course/intermediate/const-correctness.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"11. Const correctness 🚧"
 title:				"Const correctness"
 description:		"Lesson: const correctness in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Const correctness
 

--- a/content/learn/course/intermediate/constants.mdx
+++ b/content/learn/course/intermediate/constants.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"4. Constants (I) 🚧"
 title:				"Constants (I)"
 description:		"Lesson: constants (I) in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Constants
 

--- a/content/learn/course/intermediate/exceptions.mdx
+++ b/content/learn/course/intermediate/exceptions.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"9. Exceptions (I) 🚧"
 title:				"Exceptions (I)"
 description:		"Lesson: exceptions in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Exceptions
 

--- a/content/learn/course/intermediate/funcs-and-ops/default-arguments.mdx
+++ b/content/learn/course/intermediate/funcs-and-ops/default-arguments.mdx
@@ -5,11 +5,8 @@ title:				"Default arguments"
 description:		"Lesson: default parameter values in C++ language"
 tags:				[function, parameter, argument, default argument]
 hide_title:			true
+completion: false
 ---
-
-{/* Presets */}
-import NotFinished				from '@site/i18n/en/presets/NotFinished.mdx';
-import ImproveSection			from '@site/i18n/en/presets/ImproveSection.mdx';
 
 {/* Components */}
 import CustomCodeBlock			from '@site-comps/CustomCodeBlock';
@@ -18,9 +15,5 @@ import Columns					from '@site-comps/Columns';
 import Image					from '@site-comps/Image';
 import Tabs						from '@theme/Tabs';
 import TabItem					from '@theme/TabItem';
-
-{/* Codes */}
-
-<NotFinished/>
 
 # Default arguments

--- a/content/learn/course/intermediate/funcs-and-ops/function-overloading.mdx
+++ b/content/learn/course/intermediate/funcs-and-ops/function-overloading.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"2. Function overloading 🚧"
 title:				"Function overloading"
 description:		"Lesson: function overloading in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Function overloading
 

--- a/content/learn/course/intermediate/funcs-and-ops/operator-overloading.mdx
+++ b/content/learn/course/intermediate/funcs-and-ops/operator-overloading.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"3. Operator overloading 🚧"
 title:				"Operator overloading"
 description:		"Lesson: operator overloading in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Operator overloading
 

--- a/content/learn/course/intermediate/memory/arrays.mdx
+++ b/content/learn/course/intermediate/memory/arrays.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"2. Arrays 🚧"
 title:				"Arrays"
 description:		"Lesson: fixed-size arrays (std::array) in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Arrays
 

--- a/content/learn/course/intermediate/memory/copying.mdx
+++ b/content/learn/course/intermediate/memory/copying.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"3. Copying 🚧"
 title:				"Copying"
 description:		"Lesson: value copy mechanism in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Copying
 

--- a/content/learn/course/intermediate/memory/move-semantics.mdx
+++ b/content/learn/course/intermediate/memory/move-semantics.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"4. Moving 🚧"
 title:				"Moving"
 description:		"Lesson: value move mechanism in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Move semantics
 

--- a/content/learn/course/intermediate/memory/smart-pointers.mdx
+++ b/content/learn/course/intermediate/memory/smart-pointers.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"5. Smart pointers 🚧"
 title:				"Smart pointers"
 description:		"Lesson: smart pointers in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Smart pointers
 

--- a/content/learn/course/intermediate/memory/stack-and-heap.mdx
+++ b/content/learn/course/intermediate/memory/stack-and-heap.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"1. Stack and heap 🚧"
 title:				"Stack and heap"
 description:		"Lesson: the difference between stack and heap allocation in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Stack and heap
 

--- a/content/learn/course/intermediate/pointers.mdx
+++ b/content/learn/course/intermediate/pointers.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"3. Pointers (I) 🚧"
 title:				"Pointers (I)"
 description:		"Lesson: pointers (I) in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Pointers
 

--- a/content/learn/course/intermediate/preprocessor.mdx
+++ b/content/learn/course/intermediate/preprocessor.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"5. Preprocessor (I) 🚧"
 title:				"Preprocessor (I)"
 description:		"Lesson: preprocessor (I) in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Preprocessor
 

--- a/content/learn/course/intermediate/references.mdx
+++ b/content/learn/course/intermediate/references.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"2. References (II) 🚧"
 title:				"References (II)"
 description:		"Lesson: References (II) in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # References
 

--- a/content/learn/course/intermediate/templates.mdx
+++ b/content/learn/course/intermediate/templates.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"8. Templates (I) 🚧"
 title:				"Templated functions"
 description:		"Lesson: function templates in C++ language"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Function templates
 

--- a/content/learn/editing-code/refactoring.mdx
+++ b/content/learn/editing-code/refactoring.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 2
+completion: false
 ---
 
 # Refactoring
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/content/learn/editing-code/using-debugger.mdx
+++ b/content/learn/editing-code/using-debugger.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 1
+completion: false
 ---
 
 # Using debugger
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/content/learn/golden-advices/memory.mdx
+++ b/content/learn/golden-advices/memory.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 1
+completion: false
 ---
 
 # Working with memory
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/content/tools/online/comparison.mdx
+++ b/content/tools/online/comparison.mdx
@@ -1,10 +1,8 @@
 ---
 sidebar_position: 0
 title: 📊 Comparison
+completion: false
 ---
 
 # Online tools comparison
 
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/content/tools/online/godbolt.mdx
+++ b/content/tools/online/godbolt.mdx
@@ -1,9 +1,7 @@
 ---
 sidebar_position: 3
+completion: false
 ---
 
 # Using godbolt.org
 
-import NotFinished from '@site/i18n/en/presets/NotFinished.mdx';
-
-<NotFinished/>

--- a/content/tools/online/replit.mdx
+++ b/content/tools/online/replit.mdx
@@ -5,6 +5,7 @@ title:				Using Replit.com
 tags:				[editor, compiler, gcc, clang, tool, ide]
 description:		"Using Replit.com to program in C++ language"
 hide_title:			true
+completion: false
 ---
 
 {/* Components */}
@@ -13,10 +14,7 @@ import Tabs				from '@theme/Tabs';
 import TabItem			from '@theme/TabItem';
 
 {/* Presets */}
-import NotFinished		from '@site/i18n/en/presets/NotFinished.mdx';
 import ImproveSection	from "@site/i18n/en/presets/ImproveSection.mdx";
-
-<NotFinished/>
 
 # Using Replit.com
 

--- a/content/tools/online/wandbox.mdx
+++ b/content/tools/online/wandbox.mdx
@@ -1,9 +1,7 @@
 ---
 sidebar_position: 2
+completion: false
 ---
 
 # Using wandbox.org
 
-import NotFinished from '@site/i18n/en/presets/NotFinished.mdx';
-
-<NotFinished/>

--- a/content/tools/standalone/compilers/setup-clang-macos.mdx
+++ b/content/tools/standalone/compilers/setup-clang-macos.mdx
@@ -4,10 +4,7 @@ title:				Setup Clang on MacOS
 description:		Learn how to setup Clang C++ Compiler on MacOS easily.
 tags:				[compiler, tool, clang, mac]
 hide_title:			true
+completion: false
 ---
-
-import NotFinished		from '@site/i18n/en/presets/NotFinished.mdx';
-
-<NotFinished/>
 
 # Clang setup on MacOS

--- a/content/tools/standalone/compilers/setup-clang-windows.mdx
+++ b/content/tools/standalone/compilers/setup-clang-windows.mdx
@@ -4,10 +4,7 @@ title:				Setup Clang on Windows
 description:		Learn how to setup Clang C++ Compiler on Windows easily.
 tags:				[compiler, tool, clang, windows]
 hide_title:			true
+completion: false
 ---
-
-import NotFinished		from '@site/i18n/en/presets/NotFinished.mdx';
-
-<NotFinished/>
 
 # Clang setup on Windows

--- a/content/tools/standalone/compilers/setup-gcc-macos.mdx
+++ b/content/tools/standalone/compilers/setup-gcc-macos.mdx
@@ -4,10 +4,7 @@ title:				Setup GCC on MacOS
 description:		Learn how to setup GNU C++ Compiler on MacOS easily.
 tags:				[compiler, tool, gcc, mac]
 hide_title:			true
+completion: false
 ---
-
-import NotFinished		from '@site/i18n/en/presets/NotFinished.mdx';
-
-<NotFinished/>
 
 # GCC setup on MacOS

--- a/content/tools/standalone/editors/setup-clion.mdx
+++ b/content/tools/standalone/editors/setup-clion.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 3
+completion: false
 ---
 
 # CLion setup
-
-import NotFinished from '@site/i18n/en/presets/NotFinished.mdx';
-
-<NotFinished/>

--- a/content/tools/standalone/editors/setup-qtcreator.mdx
+++ b/content/tools/standalone/editors/setup-qtcreator.mdx
@@ -1,9 +1,7 @@
 ---
 sidebar_position: 4
+completion: false
 ---
 
 # QtCreator setup
 
-import NotFinished from '@site/i18n/en/presets/NotFinished.mdx';
-
-<NotFinished/>

--- a/content/tools/standalone/editors/setup-vscode.mdx
+++ b/content/tools/standalone/editors/setup-vscode.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 1
+completion: false
 ---
 
 # Visual Studio Code setup
-
-import NotFinished from '@site/i18n/en/presets/NotFinished.mdx';
-
-<NotFinished/>

--- a/content/tools/standalone/editors/vs2022/creating-projects.mdx
+++ b/content/tools/standalone/editors/vs2022/creating-projects.mdx
@@ -5,12 +5,10 @@ sidebar_label:		Creating projects
 description:		Learn how to create projects in Visual Studio 2022
 tags:				[project, visual-studio, editor, compiler, tool, windows]
 hide_title:			true
+completion: false
 ---
 
-import NotFinished		from '@site/i18n/en/presets/NotFinished.mdx';
 import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-
-<NotFinished />
 
 # Creating projects in VS 2022
 

--- a/content/tools/standalone/editors/vs2022/managing-projects.mdx
+++ b/content/tools/standalone/editors/vs2022/managing-projects.mdx
@@ -5,12 +5,10 @@ sidebar_label:		Managing projects
 description:		Learn how to manage projects and edit their settings in Visual Studio 2022
 tags:				[project, management, visual-studio, editor, compiler, settings, tool, windows]
 hide_title:			true
+completion: false
 ---
 
-import NotFinished		from '@site/i18n/en/presets/NotFinished.mdx';
 import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-
-<NotFinished />
 
 # Managing projects in VS 2022
 

--- a/content/tools/standalone/editors/vs2022/setup.mdx
+++ b/content/tools/standalone/editors/vs2022/setup.mdx
@@ -5,12 +5,10 @@ sidebar_label:		Installation
 description:		Learn how to setup Visual Studio 2022 easily
 tags:				[visual-studio, editor, compiler, tool, windows]
 hide_title:			true
+completion: false
 ---
 
-import NotFinished		from '@site/i18n/en/presets/NotFinished.mdx';
 import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-
-<NotFinished />
 
 # Visual Studio 2022 setup
 

--- a/content/tools/standalone/editors/vs2022/using-debugger.mdx
+++ b/content/tools/standalone/editors/vs2022/using-debugger.mdx
@@ -5,12 +5,10 @@ sidebar_label:		Using debugger
 description:		Learn how to use debugger in Visual Studio 2022
 tags:				[debugger, visual-studio, editor, compiler, tool, windows]
 hide_title:			true
+completion: false
 ---
 
-import NotFinished		from '@site/i18n/en/presets/NotFinished.mdx';
 import ImproveSection	from '@site/i18n/en/presets/ImproveSection.mdx';
-
-<NotFinished />
 
 # Using debugger in VS 2022
 

--- a/i18n/pl/code.json
+++ b/i18n/pl/code.json
@@ -260,7 +260,7 @@
   },
   "theme.ErrorPageContent.tryAgain": {
     "message": "Spróbuj ponownie",
-    "description": "The label of the button to try again when the page crashed"
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
   },
   "theme.BackToTopButton.buttonAriaLabel": {
     "message": "Powrót do góry strony",
@@ -354,27 +354,121 @@
     "description": "The ARIA label for the link to full blog posts from excerpts"
   },
   "removed in C++98": {
-    "message": "removed in C++98"
+    "message": "usunięto w C++98"
   },
   "removed in C++03": {
-    "message": "removed in C++03"
+    "message": "usunięto w C++03"
   },
   "removed in C++11": {
-    "message": "removed in C++11"
+    "message": "usunięto w C++11"
   },
   "removed in C++14": {
-    "message": "removed in C++14"
+    "message": "usunięto w C++14"
   },
   "removed in C++17": {
-    "message": "removed in C++17"
+    "message": "usunięto w C++17"
   },
   "removed in C++20": {
-    "message": "removed in C++20"
+    "message": "usunięto w C++20"
   },
   "removed in C++23": {
-    "message": "removed in C++23"
+    "message": "usunięto w C++23"
+  },
+  "removed in C++26": {
+    "message": "usunięto w C++26"
   },
   "See full code": {
     "message": "Zobacz pełen kod"
+  },
+  "Your completely free,": {
+    "message": "Całkowicie darmowa,"
+  },
+  "open source": {
+    "message": "otwarto-źródłowa"
+  },
+  "all-in-one website about C++.": {
+    "message": "pełna strona o języku C++."
+  },
+  "deprecated": {
+    "message": "przestarzały"
+  },
+  "deprecated in C++26": {
+    "message": "przestarzały od C++26"
+  },
+  "until C++26": {
+    "message": "przed C++26"
+  },
+  "since C++26": {
+    "message": "od C++26"
+  },
+  "deleted": {
+    "message": "usunięte"
+  },
+  "Note, this article is not finished! You can help by editing this doc page.": {
+    "message": "Uwaga, ten artykuł nie jest skończony! Możesz pomóc edytując tę stronę dokumentacji."
+  },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "1 element|{count} elementy|{count} elementów",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.admonition.warning": {
+    "message": "Uwaga",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "Rozwiń kategorię panelu bocznego '{label}'",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "Zwiń kategorię panelu bocznego '{label}'",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "Główny",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "Panel boczny dokumentów",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "Zamknij panel nawigacji",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "Przełączanie panelu nawigacyjnego",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.blog.author.pageTitle": {
+    "message": "{authorName} - {nPosts}",
+    "description": "The title of the page for a blog author"
+  },
+  "theme.blog.authorsList.pageTitle": {
+    "message": "Autorzy",
+    "description": "The title of the authors page"
+  },
+  "theme.blog.authorsList.viewAll": {
+    "message": "Zobacz wszystkich autorów",
+    "description": "The label of the link targeting the blog authors page"
+  },
+  "theme.blog.author.noPosts": {
+    "message": "Ta osoba nie napisała jeszcze żadnego posta.",
+    "description": "The text for authors with 0 blog post"
+  },
+  "theme.contentVisibility.unlistedBanner.title": {
+    "message": "Niepubliczna strona",
+    "description": "The unlisted content banner title"
+  },
+  "theme.contentVisibility.unlistedBanner.message": {
+    "message": "Ta strona jest niepubliczna. Wyszukiwarki nie będą jej indeksować, a dostęp do niej będą mieli tylko użytkownicy posiadający bezpośredni link.",
+    "description": "The unlisted content banner message"
+  },
+  "theme.contentVisibility.draftBanner.title": {
+    "message": "Draft page",
+    "description": "The draft content banner title"
+  },
+  "theme.contentVisibility.draftBanner.message": {
+    "message": "Ta strona to szkic. Będzie widoczna tylko w trybie deweloperskim i zostanie wykluczona z wersji produkcyjnej.",
+    "description": "The draft content banner message"
   }
 }

--- a/i18n/pl/docusaurus-plugin-content-docs-features/current/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-features/current/index.mdx
@@ -1,10 +1,7 @@
 ---
 sidebar_position: 1
 slug: /
+completion: false
 ---
 
 # Możliwości
-
-import NotFinished from '@site/i18n/pl/presets/NotFinished.mdx';
-
-<NotFinished/>

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/compilation-process.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/compilation-process.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 2
+completion: false
 ---
 
 # Proces kompilacji
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/linker.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/linker.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 4
+completion: false
 ---
 
 # Linker
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/multiple-files.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/multiple-files.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 5
+completion: false
 ---
 
 # Wiele plików
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/preprocessor.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/preprocessor.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 3
+completion: false
 ---
 
 # Preprocesor
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/target-types.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/target-types.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 6
+completion: false
 ---
 
 # Typy docelowe kompilacji
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/what-is-compiler.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/what-is-compiler.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 1
+completion: false
 ---
 
 # Czym jest kompilator
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/aliases.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/aliases.mdx
@@ -5,11 +5,8 @@ title:				Aliasy
 description:		"Lekcja: podstawy aliasów w języku C++"
 tags:				[alias, using, typedef]
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from '@site/i18n/pl/presets/NotFinished.mdx';
-
-<NotFinished/>
 
 # Aliasy
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/arrays/algorithms.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/arrays/algorithms.mdx
@@ -2,6 +2,7 @@
 title:				Używanie algorytmów
 description: 		"Lekcja: manipulowanie vector-ami za pomocą algorytmów w języku C++"
 hide_title:			true
+completion: false
 ---
 
 {/* Components */}
@@ -11,8 +12,6 @@ import VersionTabs from "@site-comps/VersionTabs";
 import Image      from "@site-comps/Image";
 
 {/* Presets */}
-
-import NotFinished		from "@site/i18n/pl/presets/NotFinished.mdx";
 import ImproveSection	from "@site/i18n/pl/presets/ImproveSection.mdx";
 
 {/* Codes */}
@@ -21,8 +20,6 @@ import AlgoIntroExampleUntilCpp20	from "./_codes/algo-intro-example-until-cpp20.
 
 import AlgosOverviewCpp20			from "./_codes/algos-overview-cpp20.mdx";
 import AlgosOverviewUntilCpp20		from "./_codes/algos-overview-until-cpp20.mdx";
-
-<NotFinished />
 
 # Używanie algorytmów
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/arrays/exercises.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/arrays/exercises.mdx
@@ -4,10 +4,7 @@ sidebar_label:		"3. Ćwiczenia 🚧"
 title:				Ćwiczenia
 description: 		"Lekcja: ćwiczenia z użyciem vectora w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Ćwiczenia

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/arrays/intro-to-vector.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/arrays/intro-to-vector.mdx
@@ -4,18 +4,16 @@ sidebar_label:		"1. Wstęp do vector-ów"
 title:				Wstęp do vector-ów
 description: 		"Lekcja: wstęp do tablic z użyciem vectora w języku C++"
 hide_title:			true
+completion: false
 ---
 
 {/* Components */}
 import Image			from "@site-comps/Image";
 
 {/* Presets */}
-import NotFinished		from "@site/i18n/pl/presets/NotFinished.mdx";
 import ImproveSection	from "@site/i18n/pl/presets/ImproveSection.mdx";
 import Tabs				from '@theme/Tabs';
 import TabItem			from "@theme/TabItem";
-
-<NotFinished />
 
 # Wstęp do `std::vector`
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/articles/console.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/articles/console.mdx
@@ -4,16 +4,12 @@ sidebar_label:		🖥 Konsola
 title:				Konsola
 tags:				[konsola, zależne-od-systemu]
 hide_title:			true
+completion: false
 ---
 
 {/* Components */}
 import Tabs			from "@theme/Tabs";
 import TabItem		from "@theme/TabItem";
-
-{/* Presets */}
-import NotFinished	from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Konsola
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/articles/random.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/articles/random.mdx
@@ -15,9 +15,6 @@ import CustomCodeBlock		from "@site-comps/CustomCodeBlock";
 import Image				from "@site-comps/Image";
 import Replit				from "@site-comps/Replit";
 
-{/* Presets */}
-import NotFinished			from "@site/i18n/pl/presets/NotFinished.mdx";
-
 # Liczby pseudolosowe
 
 <center>

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/conditions.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/conditions.mdx
@@ -5,16 +5,12 @@ title:				"Instrukcje warunkowe"
 description:		"Lekcja: instrukcje warunkowe w języku C++"
 tags:				[warunki, if, else, else-if]
 hide_title:			true
+completion: false
 ---
 
 {/* Components */}
 import Tabs			from "@theme/Tabs";
 import TabItem		from "@theme/TabItem";
-
-{/* Presets */}
-import NotFinished	from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished/>
 
 # Instrukcje warunkowe (if, else)
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/conditions/compound.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/conditions/compound.mdx
@@ -11,9 +11,6 @@ hide_title:			true
 import Tabs			from "@theme/Tabs";
 import TabItem		from "@theme/TabItem";
 
-{/* Presets */}
-import NotFinished	from "@site/i18n/en/presets/NotFinished.mdx";
-
 
 # Żłożone warunki
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/conditions/intro.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/conditions/intro.mdx
@@ -11,9 +11,6 @@ hide_title:			true
 import Tabs			from "@theme/Tabs";
 import TabItem		from "@theme/TabItem";
 
-{/* Presets */}
-import NotFinished	from "@site/i18n/en/presets/NotFinished.mdx";
-
 # Wprowadzenie do Warunków
 
 Dotychczas tworzyliśmy programy, które za każdym razem działały tak samo.

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/enums.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/enums.mdx
@@ -5,10 +5,8 @@ title:				Enumeracje
 description:		"Lekcja: podstawy enumeracji w języku C++"
 tags:				[enum, enumeracja, typ-danych]
 hide_title:			true
+completion: false
 ---
 
-import NotFinished from '@site/i18n/pl/presets/NotFinished.mdx';
-
-<NotFinished/>
-
 # Enumeracje
+

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/example-programs/advanced-calc.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/example-programs/advanced-calc.mdx
@@ -4,10 +4,7 @@ sidebar_label:		➗ Zaawansowany kalkulator
 title:				Zaawansowany kalkulator
 description:		"Przykładowy program: zaawansowany kalkulator w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from '@site/i18n/pl/presets/NotFinished.mdx';
-
-<NotFinished/>
 
 # Zaawansowany kalkulator

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/example-programs/combat-arena.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/example-programs/combat-arena.mdx
@@ -5,6 +5,7 @@ title:				Arena walki
 description:		"Przykładowy program: arena walki (gra konsolowa) w języku C++"
 hide_title:			true
 tags: [przykład, gra, struktura, tablica, vector]
+completion: false
 ---
 
 {/* Components */}
@@ -15,13 +16,10 @@ import Tabs 			from '@theme/Tabs';
 import TabItem 			from '@theme/TabItem';
 
 {/* Presets */}
-import NotFinished		from '@site/i18n/pl/presets/NotFinished.mdx';
 import ImproveSection	from "@site/i18n/pl/presets/ImproveSection.mdx";
 
 {/* Codes */}
 import SourceCode		from './_codes/combat-arena-source.mdx';
-
-<NotFinished/>
 
 # Arena walki
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/example-programs/simple-calc.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/example-programs/simple-calc.mdx
@@ -5,12 +5,10 @@ title:				Podstawowy kalkulator
 description:		"Przykładowy program: zaawansowany kalkulator w języku C++"
 hide_title:			true
 tags: [przykład, matematyka, kalkulator, wejście, wyjście]
+completion: false
 ---
 
-import NotFinished		from '@site/i18n/pl/presets/NotFinished.mdx';
 import ImproveSection	from "@site/i18n/pl/presets/ImproveSection.mdx";
-
-<NotFinished/>
 
 # Podstawowy kalkulator
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/first-program.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/first-program.mdx
@@ -10,7 +10,6 @@ import Columns		from '@site-comps/Columns';
 import GoogleSlides	from '@site-comps/GoogleSlides';
 import Image		from '@site-comps/Image';
 import Tooltip		from '@site-comps/Tooltip';
-import NotFinished	from '@site/i18n/pl/presets/NotFinished.mdx';
 
 import Tabs			from '@theme/Tabs';
 import TabItem		from '@theme/TabItem';

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/first-program/common-problems.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/first-program/common-problems.mdx
@@ -6,7 +6,6 @@ import Columns		from '@site-comps/Columns';
 import GoogleSlides	from '@site-comps/GoogleSlides';
 import Image		from '@site-comps/Image';
 import Tooltip		from '@site-comps/Tooltip';
-import NotFinished	from '@site/i18n/en/presets/NotFinished.mdx';
 
 import Tabs			from '@theme/Tabs';
 import TabItem		from '@theme/TabItem';

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/functions/functions.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/functions/functions.mdx
@@ -5,10 +5,10 @@ title:				"Funkcje"
 description:		"Lekcja: funkcje w języku C++"
 tags:				[funkcja, wywołanie]
 hide_title:			true
+completion: false
 ---
 
 {/* Presets */}
-import NotFinished				from '@site/i18n/pl/presets/NotFinished.mdx';
 import ImproveSection			from '@site/i18n/pl/presets/ImproveSection.mdx';
 
 {/* Components */}
@@ -26,8 +26,6 @@ import Code_TopExampleWith					from "./_codes/top-example-with.mdx";
 import Code_ExampleReuse					from "./_codes/example-reuse.mdx";
 import Code_ExampleReuseWithParam			from "./_codes/example-reuse-with-param.mdx";
 import Code_ExampleReuseWithParams			from "./_codes/example-reuse-with-params.mdx";
-
-<NotFinished/>
 
 # Funkcje
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/loops.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/loops.mdx
@@ -5,6 +5,7 @@ title:				"Pętle"
 description:		"Lekcja: pętle w języku C++"
 tags:				[pętla, for, while, range-based-for]
 hide_title:			true
+completion: false
 ---
 
 {/* Components */}
@@ -15,9 +16,6 @@ import TabItem			from "@theme/TabItem";
 
 {/* Presets */}
 import ImproveSection	from '@site/i18n/pl/presets/ImproveSection.mdx';
-import NotFinished		from '@site/i18n/pl/presets/NotFinished.mdx';
-
-<NotFinished/>
 
 # Pętle
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/methods.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/methods.mdx
@@ -5,6 +5,7 @@ title:				"Metody"
 description:		"Lekcja: podstawy metod w języku C++"
 tags:				[metoda, konstruktor, destruktor, struktura, klasa, obiekt, programowanie-obiektowe, oop]
 hide_title:			true
+completion: false
 ---
 
 {/* Components */}
@@ -14,10 +15,7 @@ import TabItem			from '@theme/TabItem';
 import Image			from '@site-comps/Image';
 
 {/*  Presets */}
-import NotFinished		from '@site/i18n/pl/presets/NotFinished.mdx';
 import ImproveSection	from '@site/i18n/pl/presets/ImproveSection.mdx';
-
-<NotFinished/>
 
 # Metody
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/namespaces.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/namespaces.mdx
@@ -5,10 +5,7 @@ title:				Przestrzenie nazw
 description:		"Lekcja: podstawy przestrzeni nazw w języku C++"
 tags:				[namespace, przestrzeń-nazw]
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from '@site/i18n/pl/presets/NotFinished.mdx';
-
-<NotFinished/>
 
 # Przestrzenie nazw

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/polymorphism.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/polymorphism.mdx
@@ -5,10 +5,7 @@ title:				Polimorfizm
 description:		"Lekcja: podstawy polimorfizmu w języku C++"
 tags:				[polimorfizm, virtual, dziedziczenie, struktura, klasa, obiekt, programowanie-obiektowe, oop]
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from '@site/i18n/pl/presets/NotFinished.mdx';
-
-<NotFinished/>
 
 # Polimorfizm

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/references.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/references.mdx
@@ -5,17 +5,12 @@ title:				Referencje
 description:		"Lekcja: podstawy referencji w języku C++"
 tags:				[referencje, wskaźnik, pamięć]
 hide_title:			true
+completion: false
 ---
 
 {/* Comps */}
 
 import Columns from "@site-comps/Columns";
-
-{/* Presets */}
-
-import NotFinished from '@site/i18n/pl/presets/NotFinished.mdx';
-
-<NotFinished/>
 
 # Referencje
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/structures.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/structures.mdx
@@ -13,7 +13,6 @@ import CustomCodeBlock	from "@site-comps/CustomCodeBlock";
 import Image			from "@site-comps/Image";
 
 {/* Presets */}
-import NotFinished		from '@site/i18n/pl/presets/NotFinished.mdx';
 import ImproveSection	from '@site/i18n/pl/presets/ImproveSection.mdx';
 
 # Struktury

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/variables/operations.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/variables/operations.mdx
@@ -7,9 +7,6 @@ tags:				[operacja, zmienna, deklaracja, definicja, int, float, char]
 hide_title:			true
 ---
 
-{/* Presets */}
-import NotFinished		from '@site/i18n/pl/presets/NotFinished.mdx';
-
 {/* Components */}
 import Tabs				from '@theme/Tabs';
 import TabItem			from '@theme/TabItem';

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/variables/strings.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/variables/strings.mdx
@@ -8,7 +8,6 @@ hide_title:			true
 ---
 
 {/* Presets */}
-import NotFinished		from '@site/i18n/pl/presets/NotFinished.mdx';
 import ImproveSection	from '@site/i18n/pl/presets/ImproveSection.mdx';
 
 {/* Components */}

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/variables/strings/common-problems.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/variables/strings/common-problems.mdx
@@ -8,7 +8,6 @@ import Columns		from '@site-comps/Columns';
 import GoogleSlides	from '@site-comps/GoogleSlides';
 import Image		from '@site-comps/Image';
 import Tooltip		from '@site-comps/Tooltip';
-import NotFinished	from '@site/i18n/en/presets/NotFinished.mdx';
 
 import Tabs			from '@theme/Tabs';
 import TabItem		from '@theme/TabItem';

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/class-namespaces.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/class-namespaces.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"7. Przestrzeń nazw klasy 🚧"
 title:				"Przestrzeń nazw klasy"
 description:		"Lekcja: Przestrzeń nazw klasy w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Przestrzeń nazw klasy
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/const-methods.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/const-methods.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"4. Metody stałych 🚧"
 title:				"Metody stałych"
 description:		"Lekcja: metody stałych obiektów w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Metody stałych obiektów
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/constructors.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/constructors.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"2. Konstruktory (I) 🚧"
 title:				"Konstruktory (I)"
 description:		"Lekcja: konstruktory klas (I) w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Konstruktory
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/destructors.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/destructors.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"3. Destruktory 🚧"
 title:				"Destruktory"
 description:		"Lekcja: destruktory klas w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Destruktory
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/intro.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/intro.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"1. Wstęp 🚧"
 title:				"Wstęp do klas"
 description:		"Lekcja: wstęp do klas w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Wstęp do klas
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/nested-classes.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/nested-classes.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"6. Klasy zagnieżdżone 🚧"
 title:				"Klasy zagnieżdżone"
 description:		"Lekcja: zagnieżdżanie klas w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Klasy zagnieżdżone
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/static-methods.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/static-methods.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"5. Metody statyczne 🚧"
 title:				"Metody statyczne"
 description:		"Lekcja: statyczne metody klas w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Statyczne metody
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/const-correctness.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/const-correctness.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"11. Poprawność stałych 🚧"
 title:				"Poprawność stałych"
 description:		"Lekcja: poprawność używania stałych w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Poprawność stałych
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/constants.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/constants.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"4. Stałe (I) 🚧"
 title:				"Stałe (I)"
 description:		"Lekcja: stałe (I) w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Stałe
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/exceptions.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/exceptions.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"8. Wyjątki (I) 🚧"
 title:				"Wyjątki (I)"
 description:		"Lekcja: wyjątki w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Wyjątki
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/funcs-and-ops/default-arguments.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/funcs-and-ops/default-arguments.mdx
@@ -5,10 +5,10 @@ title:				Domyślne argumenty
 description:		"Lekcja: domyślne wartości parametrów w języku C++"
 tags:				[funkcja, parametr, argument, argument domyślny]
 hide_title:			true
+completion: false
 ---
 
 {/* Presets */}
-import NotFinished				from '@site/i18n/pl/presets/NotFinished.mdx';
 import ImproveSection			from '@site/i18n/pl/presets/ImproveSection.mdx';
 
 {/* Components */}
@@ -22,8 +22,6 @@ import TabItem					from '@theme/TabItem';
 {/* Codes */}
 import Code_ExampleDefaultParam				from "./_codes/functions/example-default-param.mdx";
 import Code_ExampleMultipleDefaultParams	from "./_codes/functions/example-multiple-default-params.mdx";
-
-<NotFinished/>
 
 # Domyślne wartości parametrów
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/funcs-and-ops/function-overloading.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/funcs-and-ops/function-overloading.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"2. Przeładowanie funkcji 🚧"
 title:				"Przeładowanie funkcji"
 description:		"Lekcja: przeładowanie funkcji w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Przeładowanie funkcji
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/funcs-and-ops/operator-overloading.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/funcs-and-ops/operator-overloading.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"3. Przeładowanie operatorów 🚧"
 title:				"Przeładowanie operatorów"
 description:		"Lekcja: przeładowanie operatorów w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Przeładowanie operatorów
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/arrays.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/arrays.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"2. Tablice 🚧"
 title:				"Tablice"
 description:		"Lekcja: tablice (std::array) języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Tablice
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/copying.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/copying.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"3. Kopiowanie 🚧"
 title:				"Kopiowanie"
 description:		"Lekcja: działanie kopiowania wartości języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Kopiowanie
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/move-semantics.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/move-semantics.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"4. Przenoszenie 🚧"
 title:				"Przenoszenie"
 description:		"Lekcja: semantyka przeniesienia (std::move) w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Przenoszenie
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/smart-pointers.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/smart-pointers.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"5. Inteligentne wskaźniki 🚧"
 title:				"Inteligentne wskaźniki"
 description:		"Lekcja: inteligentne wskaźniki w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Inteligentne wskaźniki
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/stack-and-heap.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/stack-and-heap.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"1. Stos i sterta 🚧"
 title:				"Stos i sterta"
 description:		"Lekcja: różnica między alokacją na stosie a na stercie w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Stos i sterta
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/pointers.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/pointers.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"3. Wskaźniki (I) 🚧"
 title:				"Wskaźniki (I)"
 description:		"Lekcja: wskaźniki (I) w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Wskaźniki
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/preprocessor.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/preprocessor.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"5. Preprocesor (I) 🚧"
 title:				"Preprocesor (I)"
 description:		"Lekcja: preprocesor (I) w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Preprocesor
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/references.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/references.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"2. Referencje (II) 🚧"
 title:				"Referencje (II)"
 description:		"Lekcja: referencje (II) w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Referencje
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/templates.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/templates.mdx
@@ -4,11 +4,8 @@ sidebar_label:		"7. Szablony (I) 🚧"
 title:				"Szablony funkcji"
 description:		"Lekcja: szablony funkcji w języku C++"
 hide_title:			true
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Szablony funkcji
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/editing-code/refactoring.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/editing-code/refactoring.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 2
+completion: false
 ---
 
 # Refactorowanie
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/editing-code/using-debugger.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/editing-code/using-debugger.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 1
+completion: false
 ---
 
 # Używanie debuggera
-
-import NotFinished from "@site/i18n/en/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/comparison.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/comparison.mdx
@@ -1,10 +1,8 @@
 ---
 sidebar_position: 0
 title: 📊 Porównanie
+completion: false
 ---
 
 # Porównanie narzędzi online
 
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/godbolt.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/godbolt.mdx
@@ -1,9 +1,7 @@
 ---
 sidebar_position: 3
+completion: false
 ---
 
 # Korzystanie z godbolt.org
 
-import NotFinished from '@site/i18n/pl/presets/NotFinished.mdx';
-
-<NotFinished/>

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/replit.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/replit.mdx
@@ -5,6 +5,7 @@ title:				Korzystanie z Replit.com
 tags:				[edytor, kompilator, gcc, clang, narzędzie]
 description:		"Korzystanie z Replit.com do programowania w C++"
 hide_title:			true
+completion: false
 ---
 
 {/* Components */}
@@ -13,10 +14,7 @@ import Tabs				from '@theme/Tabs';
 import TabItem			from '@theme/TabItem';
 
 {/* Presets */}
-import NotFinished		from '@site/i18n/pl/presets/NotFinished.mdx';
 import ImproveSection	from "@site/i18n/pl/presets/ImproveSection.mdx";
-
-<NotFinished/>
 
 # Korzystanie z Replit.com
 

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/wandbox.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/wandbox.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 2
+completion: false
 ---
 
 # Korzystanie z wandbox.org
-
-import NotFinished from '@site/i18n/pl/presets/NotFinished.mdx';
-
-<NotFinished/>

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-clang-linux.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-clang-linux.mdx
@@ -4,11 +4,8 @@ title:				Instalacja Clang (Linux)
 description:		Naucz się jak skonfigurować Clang (kompilator C++) na Linuksie w prosty sposób.
 tags:				[kompilator, narzędzie, clang, linux]
 hide_title:			true
+completion: false
 ---
-
-import NotFinished		from '@site/i18n/en/presets/NotFinished.mdx';
-
-<NotFinished/>
 
 # Instalacja Clang na Linuksie
 

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-clang-macos.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-clang-macos.mdx
@@ -4,10 +4,7 @@ title:				Instalacja Clang (MacOS)
 description:		Naucz się jak skonfigurować Clang (kompilator C++) na MacOS w prosty sposób.
 tags:				[compiler, tool, clang, mac]
 hide_title:			true
+completion: false
 ---
-
-import NotFinished		from '@site/i18n/en/presets/NotFinished.mdx';
-
-<NotFinished/>
 
 # Instalacja Clang na MacOS

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-clang-windows.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-clang-windows.mdx
@@ -6,8 +6,6 @@ tags:				[kompilator, narzędzie, clang, windows]
 hide_title:			true
 ---
 
-import NotFinished		from '@site/i18n/en/presets/NotFinished.mdx';
-
 W tym artykule dowiesz się jak zainstalować Clang w systemie Windows w bardzo prosty sposób.
 
 # Instalacja i konfiguracja

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-gcc-macos.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-gcc-macos.mdx
@@ -4,10 +4,7 @@ title:				Instalacja GCC (MacOS)
 description:		Naucz się jak skonfigurować GCC (kompilator C++) na MacOS w prosty sposób.
 tags:				[compiler, tool, gcc, mac]
 hide_title:			true
+completion: false
 ---
-
-import NotFinished		from '@site/i18n/en/presets/NotFinished.mdx';
-
-<NotFinished/>
 
 # Instalacja GCC na MacOS

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/setup-clion.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/setup-clion.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 3
+completion: false
 ---
 
 # CLion - konfiguracja
-
-import NotFinished from '@site/i18n/pl/presets/NotFinished.mdx';
-
-<NotFinished/>

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/setup-qtcreator.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/setup-qtcreator.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 4
+completion: false
 ---
 
 # QtCreator - konfiguracja
-
-import NotFinished from '@site/i18n/pl/presets/NotFinished.mdx';
-
-<NotFinished/>

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/setup-vscode.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/setup-vscode.mdx
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 1
+completion: false
 ---
 
 # Visual Studio Code - konfiguracja
-
-import NotFinished from '@site/i18n/pl/presets/NotFinished.mdx';
-
-<NotFinished/>

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/creating-projects.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/creating-projects.mdx
@@ -5,12 +5,10 @@ sidebar_label:		Tworzenie projektów
 description:		Learn how to create projects in Visual Studio 2022
 tags:				[projekt, visual-studio, edytor, kompilator, narzędzie, windows]
 hide_title:			true
+completion: false
 ---
 
-import NotFinished		from '@site/i18n/pl/presets/NotFinished.mdx';
 import ImproveSection	from '@site/i18n/pl/presets/ImproveSection.mdx';
-
-<NotFinished />
 
 # Tworzenie projektów w Visual Studio 2022
 

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/managing-projects.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/managing-projects.mdx
@@ -5,12 +5,10 @@ sidebar_label:		Zarządzanie projektami
 description:		Naucz się jak zarządzać projektami w Visual Studio 2022
 tags:				[projekt, zarządzanie, visual-studio, edytor, kompilator, ustawienia, narzędzie, windows]
 hide_title:			true
+completion: false
 ---
 
-import NotFinished		from '@site/i18n/pl/presets/NotFinished.mdx';
 import ImproveSection	from '@site/i18n/pl/presets/ImproveSection.mdx';
-
-<NotFinished />
 
 # Zarządzenie projektami w Visual Studio 2022
 

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/setup.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/setup.mdx
@@ -5,12 +5,10 @@ sidebar_label:		Instalacja
 description:		Naucz się jak zainstalować Visual Studio 2022 w prosty sposób.
 tags:				[visual-studio, edytor, kompilator, narzędzie, windows]
 hide_title:			true
+completion: false
 ---
 
-import NotFinished		from '@site/i18n/pl/presets/NotFinished.mdx';
 import ImproveSection	from '@site/i18n/pl/presets/ImproveSection.mdx';
-
-<NotFinished />
 
 # Instalacja Visual Studio 2022
 

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/using-debugger.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/using-debugger.mdx
@@ -5,12 +5,10 @@ sidebar_label:		Debugowanie
 description:		Naucz się jak korzystać z debuggera w Visual Studio 2022
 tags:				[debugger, visual-studio, edytor, narzędzie, windows]
 hide_title:			true
+completion: false
 ---
 
-import NotFinished		from '@site/i18n/pl/presets/NotFinished.mdx';
 import ImproveSection	from '@site/i18n/pl/presets/ImproveSection.mdx';
-
-<NotFinished />
 
 # Używanie debuggera w VS 2022
 

--- a/i18n/pl/docusaurus-plugin-content-docs/current.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current.json
@@ -80,11 +80,11 @@
     "description": "The label for category Members of string in sidebar defaultSidebar"
   },
   "sidebar.defaultSidebar.category.Standard Library": {
-    "message": "Standard Library",
+    "message": "Biblioteka standardowa",
     "description": "The label for category Standard Library in sidebar defaultSidebar"
   },
   "sidebar.defaultSidebar.category.Mathematical Functions": {
-    "message": "Mathematical Functions",
+    "message": "Funkcje matematyczne",
     "description": "The label for category Mathematical Functions in sidebar defaultSidebar"
   },
   "sidebar.defaultSidebar.category.Abs": {
@@ -166,5 +166,201 @@
   "sidebar.defaultSidebar.category.stack": {
     "message": "stack",
     "description": "The label for category stack in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Basic Operations": {
+    "message": "Podstawowe operacje",
+    "description": "The label for category Basic Operations in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Exponential Functions": {
+    "message": "Funkcje wykładnicze",
+    "description": "The label for category Exponential Functions in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Power Functions": {
+    "message": "Funkcje potęgowe",
+    "description": "The label for category Power Functions in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Trigonometric Functions": {
+    "message": "Funkcje trygonometryczne",
+    "description": "The label for category Trigonometric Functions in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Hyperbolic Functions": {
+    "message": "Funkcje hiperboliczne",
+    "description": "The label for category Hyperbolic Functions in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Error and Gamma Functions": {
+    "message": "Funkcje błędów i gamma",
+    "description": "The label for category Error and Gamma Functions in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Nearest integer floating point operations": {
+    "message": "Operacje na najbliższej liczbie całkowitej",
+    "description": "The label for category Nearest integer floating point operations in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Floating point manipulation functions": {
+    "message": "Funkcje manipulacji liczbami zmiennoprzecinkowymi",
+    "description": "The label for category Floating point manipulation functions in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Classification and comparison": {
+    "message": "Klasyfikacja i porównanie",
+    "description": "The label for category Classification and comparison in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Types": {
+    "message": "Types",
+    "description": "The label for category Types in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Macro Constants": {
+    "message": "Stałe (makra)",
+    "description": "The label for category Macro Constants in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.forward_list": {
+    "message": "forward_list",
+    "description": "The label for category forward_list in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Searching": {
+    "message": "Wyszukiwanie",
+    "description": "The label for category Searching in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Rangified": {
+    "message": "Rangified",
+    "description": "The label for category Rangified in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Ordinary": {
+    "message": "Zwykłe",
+    "description": "The label for category Ordinary in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Determining conditions": {
+    "message": "Determining conditions",
+    "description": "The label for category Determining conditions in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Other non-modifying": {
+    "message": "Inne niemodyfikujące",
+    "description": "The label for category Other non-modifying in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Random operations": {
+    "message": "Operacje losowe",
+    "description": "The label for category Random operations in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Modifying": {
+    "message": "Modyfikujące",
+    "description": "The label for category Modifying in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Partitioning": {
+    "message": "Rozdzielające",
+    "description": "The label for category Partitioning in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Sorting": {
+    "message": "Sortujące",
+    "description": "The label for category Sorting in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Binary search": {
+    "message": "Wyszukiwanie binarne",
+    "description": "The label for category Binary search in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Set": {
+    "message": "Set",
+    "description": "The label for category Set in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Other operations on sorted ranges": {
+    "message": "Inne operacje na posortowanych zakresach",
+    "description": "The label for category Other operations on sorted ranges in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Heap": {
+    "message": "Heap",
+    "description": "The label for category Heap in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Min/max": {
+    "message": "Min/max",
+    "description": "The label for category Min/max in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Comparison": {
+    "message": "Porównania",
+    "description": "The label for category Comparison in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Permutation": {
+    "message": "Permutacje",
+    "description": "The label for category Permutation in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Numeric": {
+    "message": "Numeryczne",
+    "description": "The label for category Numeric in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Operations on uninitialized memory": {
+    "message": "Operacje na niezainicjalizowanej pamięci",
+    "description": "The label for category Operations on uninitialized memory in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.C algorithms": {
+    "message": "Algorytmy z C",
+    "description": "The label for category C algorithms in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Memory": {
+    "message": "Pamięć",
+    "description": "The label for category Memory in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Smart Pointers": {
+    "message": "Smart pointery",
+    "description": "The label for category Smart Pointers in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Pointer Categories": {
+    "message": "Kategorie wskaźników",
+    "description": "The label for category Pointer Categories in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Helper classes": {
+    "message": "Pomocnicze klasy",
+    "description": "The label for category Helper classes in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.owner_less": {
+    "message": "owner_less",
+    "description": "The label for category owner_less in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Smart pointer adaptors": {
+    "message": "Adaptory smart pointerów",
+    "description": "The label for category Smart pointer adaptors in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Allocators": {
+    "message": "Alokatory",
+    "description": "The label for category Allocators in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Named Requirements": {
+    "message": "Named Requirements",
+    "description": "The label for category Named Requirements in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Basic": {
+    "message": "Podstawowe",
+    "description": "The label for category Basic in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Type properties": {
+    "message": "Operacje na typach",
+    "description": "The label for category Type properties in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Library-wide": {
+    "message": "Library-wide",
+    "description": "The label for category Library-wide in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Container": {
+    "message": "Kontenery",
+    "description": "The label for category Container in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Container element": {
+    "message": "Element kontenera",
+    "description": "The label for category Container element in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Iterator": {
+    "message": "Iterator",
+    "description": "The label for category Iterator in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Stream I/O functions": {
+    "message": "Funkcje strumieni I/O",
+    "description": "The label for category Stream I/O functions in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Formatters": {
+    "message": "Formattery",
+    "description": "The label for category Formatters in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Random Number Generation": {
+    "message": "Generowanie Liczb Losowych",
+    "description": "The label for category Random Number Generation in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Concurrency": {
+    "message": "Współbieżność",
+    "description": "The label for category Concurrency in sidebar defaultSidebar"
   }
 }

--- a/i18n/pl/docusaurus-plugin-content-docs/current/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/index.mdx
@@ -1,13 +1,10 @@
 ---
 sidebar_position: 1
 slug: /
+completion: false
 ---
 
 # Dokumentacja C++
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 ## [Biblioteka standardowa](std)
 

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/index.mdx
@@ -3,11 +3,8 @@ sidebar_position:	1
 title:				Biblioteka standardowa
 hide_title:			true
 slug: /std/
+completion: false
 ---
-
-import NotFinished from "@site/i18n/pl/presets/NotFinished.mdx";
-
-<NotFinished />
 
 # Biblioteka standardowa
 

--- a/i18n/pl/docusaurus-theme-classic/navbar.json
+++ b/i18n/pl/docusaurus-theme-classic/navbar.json
@@ -26,5 +26,9 @@
   "item.label.Community": {
     "message": "Społeczność",
     "description": "Navbar item with label Community"
+  },
+  "logo.alt": {
+    "message": "Logo języka C++",
+    "description": "The alt text of navbar logo"
   }
 }

--- a/src/components/mdx/admonitions/NotFinished.tsx
+++ b/src/components/mdx/admonitions/NotFinished.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+import Translate from "@docusaurus/Translate";
+import Admonition from "@theme/Admonition";
+
+export default function NotFinished() {
+  return (
+    <Admonition type="caution">
+      <Translate>
+        Note, this article is not finished! You can help by editing this doc page.
+      </Translate>
+    </Admonition>
+  );
+}
+
+NotFinished.isMDXComponent = true;

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -4,6 +4,7 @@ import type ContentType from "@theme/DocItem/Content";
 import type { WrapperProps } from "@docusaurus/types";
 import { useDoc } from "@docusaurus/plugin-content-docs/client";
 
+import NotFinished from "@site-comps/admonitions/NotFinished";
 import DocSettings from "@site/src/components/DocSettings";
 import CppRefAttribution from "@site-comps/CppRefAttribution";
 import DefinedIn from "@site-comps/DefinedIn";
@@ -22,6 +23,8 @@ interface FrontMatterData {
   "arrow_jumping_preset"?: string;
 
   "defined_in_headers"?: string | string[];
+
+  "completion"?: boolean;
   // Possibly other
 }
 
@@ -70,6 +73,10 @@ export default function ContentWrapper(props: Props): JSX.Element {
         )}
       </BrowserOnly>
       <FrontMatterDefinedIn frontMatter={metadata.frontMatter} />
+      {
+        metadata.frontMatter.completion === false &&
+        <NotFinished />
+      }
       <Content {...props} />
       <FrontMatterCppRefAttribution frontMatter={metadata.frontMatter} />
     </div>


### PR DESCRIPTION
## Description

Introduces a new way for adding the "This article is not complete..." notice with the following frontmatter flag:

```md
---
completion: false
---
```

Removes the existing usages of a non-declarative way.

## Type of Change

<!--- Put an `x` ( and remove spaces ) in all the boxes that apply: -->

### Changes in docs (`docs`)

- 🧹 `refactor(docs)` - removed the existing usages of a non-declarative way
- 🗑️ `chore(docs)` - added missing PL translations

### Changes in the platform (`platform`)

- ✨ `feat(platform)` - the `completion` frontmatter setting

