### PR TITLE
chore: remove legacy sidebar info

### DIFF
--- a/content/community/index.mdx
+++ b/content/community/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		👥 Community
 title:				Community
 hide_title:			true

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /
 hide_title: true

--- a/content/docs/std/algo/_category_.json
+++ b/content/docs/std/algo/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Algorithms",
-	"position": 5
-}

--- a/content/docs/std/algo/index.mdx
+++ b/content/docs/std/algo/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/algo/
 ---

--- a/content/docs/std/concepts/_category_.json
+++ b/content/docs/std/concepts/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Concepts",
-	"position": 8
-}

--- a/content/docs/std/concepts/index.mdx
+++ b/content/docs/std/concepts/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/concepts/
 ---

--- a/content/docs/std/containers/arrays/index.mdx
+++ b/content/docs/std/containers/arrays/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/containers/arrays/
 ---

--- a/content/docs/std/containers/arrays/initializer_list/constructor.mdx
+++ b/content/docs/std/containers/arrays/initializer_list/constructor.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 title:				std::initializer_list constructors
 sidebar_label:		Constructors
 description:		std::initializer_list constructors C++ documentation

--- a/content/docs/std/containers/index.mdx
+++ b/content/docs/std/containers/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/containers/
 ---

--- a/content/docs/std/containers/lists/index.mdx
+++ b/content/docs/std/containers/lists/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/containers/lists/
 ---

--- a/content/docs/std/containers/maps/index.mdx
+++ b/content/docs/std/containers/maps/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/containers/maps/
 ---

--- a/content/docs/std/containers/other/index.mdx
+++ b/content/docs/std/containers/other/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/containers/other/
 ---

--- a/content/docs/std/containers/other/span.mdx
+++ b/content/docs/std/containers/other/span.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 title:				std::span reference
 sidebar_label:		span
 description:		Summary of a std::span (usage, methods, etc.) - C++ Language

--- a/content/docs/std/containers/other/span/constructors.mdx
+++ b/content/docs/std/containers/other/span/constructors.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 title:				std::span constructors
 sidebar_label:		Constructors
 description:		std::span constructors C++ documentation

--- a/content/docs/std/containers/other/stack.mdx
+++ b/content/docs/std/containers/other/stack.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 title:				std::stack reference
 sidebar_label:		stack
 hide_title:			true

--- a/content/docs/std/containers/other/stack/constructors.mdx
+++ b/content/docs/std/containers/other/stack/constructors.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 title:				std::stack constructors
 sidebar_label:		Constructors
 hide_title:			true

--- a/content/docs/std/containers/queues/deque.mdx
+++ b/content/docs/std/containers/queues/deque.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 title:				std::deque reference
 sidebar_label:		deque
 hide_title:			true

--- a/content/docs/std/containers/queues/index.mdx
+++ b/content/docs/std/containers/queues/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/containers/queues/
 ---

--- a/content/docs/std/containers/queues/priority_queue.mdx
+++ b/content/docs/std/containers/queues/priority_queue.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 title:				std::priority_queue reference
 sidebar_label:		priority_queue
 hide_title:			true

--- a/content/docs/std/containers/queues/queue.mdx
+++ b/content/docs/std/containers/queues/queue.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 title:				std::queue reference
 sidebar_label:		queue
 hide_title:			true

--- a/content/docs/std/containers/sets/index.mdx
+++ b/content/docs/std/containers/sets/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/containers/sets/
 ---

--- a/content/docs/std/containers/strings/index.mdx
+++ b/content/docs/std/containers/strings/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/containers/strings/
 ---

--- a/content/docs/std/containers/strings/string/_category_.json
+++ b/content/docs/std/containers/strings/string/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Members of string",
-	"position": 4
-}

--- a/content/docs/std/containers/strings/string/at.mdx
+++ b/content/docs/std/containers/strings/string/at.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:		2
 title:					std::string::at() method
 sidebar_label:			at( )
 description:			std::string::at() method C++ documentation

--- a/content/docs/std/containers/strings/string/constructors.mdx
+++ b/content/docs/std/containers/strings/string/constructors.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 title:				std::string constructors
 sidebar_label:		Constructors
 description:		std::string constructors C++ documentation

--- a/content/docs/std/containers/strings/string/get_allocator.mdx
+++ b/content/docs/std/containers/strings/string/get_allocator.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 title:				std::string::get_allocator() method
 sidebar_label:		get_allocator( )
 description:		std::string::get_allocator C++ documentation

--- a/content/docs/std/containers/strings/string_view/_category_.json
+++ b/content/docs/std/containers/strings/string_view/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Members of string",
-	"position": 4
-}

--- a/content/docs/std/containers/strings/string_view/at.mdx
+++ b/content/docs/std/containers/strings/string_view/at.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:		2
 title:					std::string_view::at() method
 sidebar_label:			at( )
 description:			std::string_view::at() method C++ documentation

--- a/content/docs/std/containers/strings/string_view/constructors.mdx
+++ b/content/docs/std/containers/strings/string_view/constructors.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 title:				std::string_view constructors
 sidebar_label:		Constructors
 description:		std::string_view constructors C++ documentation

--- a/content/docs/std/date-time/_category_.json
+++ b/content/docs/std/date-time/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Date and time",
-	"position": 11
-}

--- a/content/docs/std/date-time/index.mdx
+++ b/content/docs/std/date-time/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/date-time/
 ---

--- a/content/docs/std/index.mdx
+++ b/content/docs/std/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 title:				The standard library
 hide_title:			true
 slug: /std/

--- a/content/docs/std/io/_category_.json
+++ b/content/docs/std/io/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Input and output",
-	"position": 3
-}

--- a/content/docs/std/io/index.mdx
+++ b/content/docs/std/io/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/io/
 ---

--- a/content/docs/std/iterators/_category_.json
+++ b/content/docs/std/iterators/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Iterators",
-	"position": 6
-}

--- a/content/docs/std/iterators/index.mdx
+++ b/content/docs/std/iterators/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/iterators/
 ---

--- a/content/docs/std/lang-support/_category_.json
+++ b/content/docs/std/lang-support/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Language support",
-	"position": 9
-}

--- a/content/docs/std/lang-support/index.mdx
+++ b/content/docs/std/lang-support/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/lang-support/
 ---

--- a/content/docs/std/math/_category_.json
+++ b/content/docs/std/math/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Math",
-	"position": 2
-}

--- a/content/docs/std/math/index.mdx
+++ b/content/docs/std/math/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/math/
 ---

--- a/content/docs/std/math/mathematical_functions/_category_.json
+++ b/content/docs/std/math/mathematical_functions/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Mathematical Functions",
-	"position": 2
-}

--- a/content/docs/std/math/mathematical_functions/abs/_category_.json
+++ b/content/docs/std/math/mathematical_functions/abs/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Abs",
-	"position": 3
-}

--- a/content/docs/std/math/mathematical_functions/div/_category_.json
+++ b/content/docs/std/math/mathematical_functions/div/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Div",
-	"position": 3
-}

--- a/content/docs/std/math/mathematical_functions/fmod/_category_.json
+++ b/content/docs/std/math/mathematical_functions/fmod/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Fmod",
-	"position": 3
-}

--- a/content/docs/std/math/mathematical_functions/index.mdx
+++ b/content/docs/std/math/mathematical_functions/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 title:				Mathematical functions
 sidebar_label:		Mathematical functions
 description:		Listing of common mathematical functions

--- a/content/docs/std/math/mathematical_special_functions.mdx
+++ b/content/docs/std/math/mathematical_special_functions.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 title:				Mathematical special functions
 sidebar_label:		Mathematical special functions
 description:		Listing of common mathematical functions

--- a/content/docs/std/math/numeric_algorithms.mdx
+++ b/content/docs/std/math/numeric_algorithms.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 title:				Numeric algorithms
 sidebar_label:		Numeric algorithms
 description:		Listing of common mathematical functions

--- a/content/docs/std/memory/_category_.json
+++ b/content/docs/std/memory/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Memory management",
-	"position": 10
-}

--- a/content/docs/std/memory/index.mdx
+++ b/content/docs/std/memory/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/memory/
 ---

--- a/content/docs/std/ranges/_category_.json
+++ b/content/docs/std/ranges/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Ranges",
-	"position": 7
-}

--- a/content/docs/std/ranges/index.mdx
+++ b/content/docs/std/ranges/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/ranges/
 ---

--- a/content/docs/std/utility/_category_.json
+++ b/content/docs/std/utility/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Utility",
-	"position": 12
-}

--- a/content/docs/std/utility/forward.mdx
+++ b/content/docs/std/utility/forward.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 title:				std::forward - utility
 sidebar_label:		std::forward()
 description:		std::forward C++ documentation

--- a/content/docs/std/utility/index.mdx
+++ b/content/docs/std/utility/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/utility/
 ---

--- a/content/docs/std/utility/variant.mdx
+++ b/content/docs/std/utility/variant.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 title:				std::variant - utility
 sidebar_label:		std::variant
 tags:				[variant, utility]

--- a/content/docs/useful-links.mdx
+++ b/content/docs/useful-links.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		"Useful links"
 title:				"Useful links"
 description:		"Docs: useful links about C++ language"

--- a/content/learn/compilation/_category_.json
+++ b/content/learn/compilation/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Compilation",
-	"position": 5
-}

--- a/content/learn/compilation/compilation-process.mdx
+++ b/content/learn/compilation/compilation-process.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 2
 completion: false
 ---
 

--- a/content/learn/compilation/flags/_category_.json
+++ b/content/learn/compilation/flags/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Compiler flags 🚩",
-	"position": 7
-}

--- a/content/learn/compilation/flags/fast-math.mdx
+++ b/content/learn/compilation/flags/fast-math.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 2
 sidebar_label:	"Fast math"
 title:			"Fast math - Compilation flag"
 description:	"Fast math compilation flag guide for C++ language"

--- a/content/learn/compilation/flags/lang-standard.mdx
+++ b/content/learn/compilation/flags/lang-standard.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 sidebar_label:	"Language standard"
 title:			"Language standard - Compilation flag"
 description:	"Language standard compilation flag guide for C++ language"

--- a/content/learn/compilation/flags/visibility.mdx
+++ b/content/learn/compilation/flags/visibility.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 3
 sidebar_label:	"Symbol visibility"
 title:			"Symbol visibility - Compilation flag"
 description:	"Symbol visibility compilation flag guide for C++ language"

--- a/content/learn/compilation/linker.mdx
+++ b/content/learn/compilation/linker.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 4
 completion: false
 ---
 

--- a/content/learn/compilation/multiple-files.mdx
+++ b/content/learn/compilation/multiple-files.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 5
 completion: false
 ---
 

--- a/content/learn/compilation/preprocessor.mdx
+++ b/content/learn/compilation/preprocessor.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 3
 completion: false
 ---
 

--- a/content/learn/compilation/target-types.mdx
+++ b/content/learn/compilation/target-types.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 6
 completion: false
 ---
 

--- a/content/learn/compilation/what-is-compiler.mdx
+++ b/content/learn/compilation/what-is-compiler.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 completion: false
 ---
 

--- a/content/learn/course/_category_.json
+++ b/content/learn/course/_category_.json
@@ -1,5 +1,0 @@
-{
-  "label": "C++ Course",
-  "position": 3,
-  "collapsed": false
-}

--- a/content/learn/course/advanced/_category_.json
+++ b/content/learn/course/advanced/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "🟠 Advanced",
-  "position": 4
-}

--- a/content/learn/course/advanced/classes/_category_.json
+++ b/content/learn/course/advanced/classes/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "4. Classes (II)",
-  "position": 4
-}

--- a/content/learn/course/advanced/classes/copy-constructor.mdx
+++ b/content/learn/course/advanced/classes/copy-constructor.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		"2. Copy constructors 🚧"
 title:				"Copy constructors"
 description:		"Lesson: using copy constructors in C++ language"

--- a/content/learn/course/advanced/classes/default-constructors.mdx
+++ b/content/learn/course/advanced/classes/default-constructors.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"1. Default constructors 🚧"
 title:				"Default constructors"
 description:		"Lesson: using default constructors in C++ language"

--- a/content/learn/course/advanced/classes/move-constructors.mdx
+++ b/content/learn/course/advanced/classes/move-constructors.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		"3. Move constructors 🚧"
 title:				"Move constructors"
 description:		"Lesson: using move constructors in C++ language"

--- a/content/learn/course/advanced/constants.mdx
+++ b/content/learn/course/advanced/constants.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"1. Constants (II) 🚧"
 title:				"Constants (II)"
 description:		"Lesson: constants (II) in C++ language"

--- a/content/learn/course/advanced/exceptions/_category_.json
+++ b/content/learn/course/advanced/exceptions/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "5. Exceptions (II)",
-  "position": 5
-}

--- a/content/learn/course/advanced/exceptions/in-constructor.mdx
+++ b/content/learn/course/advanced/exceptions/in-constructor.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"1. In constructor 🚧"
 title:				"Exceptions in constructors"
 description:		"Lesson: handling exceptions in constructor in C++ language"

--- a/content/learn/course/advanced/exceptions/noexcept.mdx
+++ b/content/learn/course/advanced/exceptions/noexcept.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		"2. noexcept 🚧"
 title:				"Using noexcept"
 description:		"Lesson: using noexcept specifier in C++ language"

--- a/content/learn/course/advanced/iterators.mdx
+++ b/content/learn/course/advanced/iterators.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	6
 sidebar_label:		"6. Iterators (I) 🚧"
 title:				"Iterators (I)"
 description:		"Lesson: using iterators (I) in C++ language"

--- a/content/learn/course/advanced/lambdas.mdx
+++ b/content/learn/course/advanced/lambdas.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		"3. Lambdas (II) 🚧"
 title:				"Lambdas (II)"
 description:		"Lesson: advanced lambdas (II) in C++ language"

--- a/content/learn/course/advanced/memory/_category_.json
+++ b/content/learn/course/advanced/memory/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "9. Memory (II)",
-  "position": 9
-}

--- a/content/learn/course/advanced/memory/new-and-delete.mdx
+++ b/content/learn/course/advanced/memory/new-and-delete.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		"3. new, delete 🚧"
 title:				"new and delete operators"
 description:		"Lesson: correct usage of new and delete operators in C++ language"

--- a/content/learn/course/advanced/memory/pointers.mdx
+++ b/content/learn/course/advanced/memory/pointers.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		"2. Pointers (II) 🚧"
 title:				"Pointers (II)"
 description:		"Lesson: pointers (II) in C++ language"

--- a/content/learn/course/advanced/memory/raw-arrays.mdx
+++ b/content/learn/course/advanced/memory/raw-arrays.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"1. Raw arrays 🚧"
 title:				"Raw arrays"
 description:		"Lesson: raw arrays (Type[N]) in C++ language"

--- a/content/learn/course/advanced/preprocessor.mdx
+++ b/content/learn/course/advanced/preprocessor.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	8
 sidebar_label:		"8. Preprocessor (II) 🚧"
 title:				"Preprocessor (II)"
 description:		"Lesson: preprocessor (II) in C++ language"

--- a/content/learn/course/advanced/references.mdx
+++ b/content/learn/course/advanced/references.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	7
 sidebar_label:		"7. References (III) 🚧"
 title:				"References (III)"
 description:		"Lesson: References (III) in C++ language"

--- a/content/learn/course/advanced/templates/_category_.json
+++ b/content/learn/course/advanced/templates/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "2. Templates (II)",
-  "position": 2
-}

--- a/content/learn/course/advanced/templates/aliases.mdx
+++ b/content/learn/course/advanced/templates/aliases.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		"3. Aliases 🚧"
 title:				"Templated aliases"
 description:		"Lesson: creating templated aliases in C++ language"

--- a/content/learn/course/advanced/templates/classes.mdx
+++ b/content/learn/course/advanced/templates/classes.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		"2. Classes 🚧"
 title:				"Class templates"
 description:		"Lesson: creating class templates in C++ language"

--- a/content/learn/course/advanced/templates/fold-expr.mdx
+++ b/content/learn/course/advanced/templates/fold-expr.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	5
 sidebar_label:		"5. Fold expressions 🚧"
 title:				"Fold expressions"
 description:		"Lesson: using fold expressions in C++ language"

--- a/content/learn/course/advanced/templates/functions.mdx
+++ b/content/learn/course/advanced/templates/functions.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"1. Functions 🚧"
 title:				"Function templates"
 description:		"Lesson: creating function templates in C++ language"

--- a/content/learn/course/advanced/templates/variables.mdx
+++ b/content/learn/course/advanced/templates/variables.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	4
 sidebar_label:		"4. Variables 🚧"
 title:				"Variable templates"
 description:		"Lesson: creating variable templates in C++ language"

--- a/content/learn/course/basics/_category_.json
+++ b/content/learn/course/basics/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "🟢 Basics",
-  "position": 2
-}

--- a/content/learn/course/basics/arrays/_category_.json
+++ b/content/learn/course/basics/arrays/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "5. Arrays",
-  "position": 5
-}

--- a/content/learn/course/basics/arrays/exercises.mdx
+++ b/content/learn/course/basics/arrays/exercises.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 title:				Exercises
 description:		"Lesson: exercises using vector in C++"
 hide_title:			true

--- a/content/learn/course/basics/arrays/introduction.mdx
+++ b/content/learn/course/basics/arrays/introduction.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 title:				Introduction
 description:		"Lesson: introduction to arrays in C++"
 hide_title:			true

--- a/content/learn/course/basics/articles/_category_.json
+++ b/content/learn/course/basics/articles/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "📰 Articles",
-  "position": 15
-}

--- a/content/learn/course/basics/articles/console.mdx
+++ b/content/learn/course/basics/articles/console.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		🖥 Console
 title:				Console
 tags:				[console, os-dependent]

--- a/content/learn/course/basics/articles/random.mdx
+++ b/content/learn/course/basics/articles/random.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		🎲 Randomness
 title:				Pseudo-random numbers
 description:		"Article (basics): pseudo-random numbers in C++ language"

--- a/content/learn/course/basics/comments.mdx
+++ b/content/learn/course/basics/comments.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		"2. Comments"
 description:		"Lesson: comments in C++"
 tags:				[comment]

--- a/content/learn/course/basics/example-programs/_category_.json
+++ b/content/learn/course/basics/example-programs/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "💻 Examples",
-  "position": 16
-}

--- a/content/learn/course/basics/example-programs/advanced-calc.mdx
+++ b/content/learn/course/basics/example-programs/advanced-calc.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		➗ Advanced calculator
 title:				Advanced calculator
 description:		"Example program: an advanced calculator in C++ language"

--- a/content/learn/course/basics/example-programs/combat-arena.mdx
+++ b/content/learn/course/basics/example-programs/combat-arena.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		👾 Combat arena
 title:				Combat arena
 description:		"Example program: a combat arena (game) in C++ language"

--- a/content/learn/course/basics/example-programs/simple-calc.mdx
+++ b/content/learn/course/basics/example-programs/simple-calc.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		➕ Simple calculator
 title:				Simple calculator
 description:		"Example program: a simple calculator in C++ language"

--- a/content/learn/course/basics/loops.mdx
+++ b/content/learn/course/basics/loops.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	6
 sidebar_label:		"6. Loops"
 title:				"Loops"
 description:		"Lesson: loops basics in C++ language"

--- a/content/learn/course/basics/variables/_category_.json
+++ b/content/learn/course/basics/variables/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "3. Variables",
-  "position": 3
-}

--- a/content/learn/course/basics/variables/intro.mdx
+++ b/content/learn/course/basics/variables/intro.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"1. Introduction"
 title:				"Introduction"
 description:		"Lesson: introduction to variables basics in C++"

--- a/content/learn/course/basics/variables/strings.mdx
+++ b/content/learn/course/basics/variables/strings.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		"3. Strings"
 title:				"Strings"
 description:		"Lesson: basics of string/text type in C++"

--- a/content/learn/course/intermediate/_category_.json
+++ b/content/learn/course/intermediate/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "🟡 Intermediate",
-  "position": 3
-}

--- a/content/learn/course/intermediate/classes/_category_.json
+++ b/content/learn/course/intermediate/classes/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "9. Classes (I)",
-  "position": 9
-}

--- a/content/learn/course/intermediate/classes/class-namespaces.mdx
+++ b/content/learn/course/intermediate/classes/class-namespaces.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	7
 sidebar_label:		"7. Class namespaces 🚧"
 title:				"Class namespaces"
 description:		"Lesson: class namespaces in C++ language"

--- a/content/learn/course/intermediate/classes/const-methods.mdx
+++ b/content/learn/course/intermediate/classes/const-methods.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	4
 sidebar_label:		"4. Const methods 🚧"
 title:				"Const methods"
 description:		"Lesson: methods of const objects in C++ language"

--- a/content/learn/course/intermediate/classes/constructors.mdx
+++ b/content/learn/course/intermediate/classes/constructors.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		"2. Constructors (I) 🚧"
 title:				"Constructors (I)"
 description:		"Lesson: class constructors (I) in C++ language"

--- a/content/learn/course/intermediate/classes/destructors.mdx
+++ b/content/learn/course/intermediate/classes/destructors.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		"3. Destructors 🚧"
 title:				"Destructors"
 description:		"Lesson: class destructors in C++ language"

--- a/content/learn/course/intermediate/classes/intro.mdx
+++ b/content/learn/course/intermediate/classes/intro.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"1. Introduction 🚧"
 title:				"Introduction to classes"
 description:		"Lesson: introduction to classes in C++ language"

--- a/content/learn/course/intermediate/classes/nested-classes.mdx
+++ b/content/learn/course/intermediate/classes/nested-classes.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	6
 sidebar_label:		"6. Nested classes 🚧"
 title:				"Nested classes"
 description:		"Lesson: nesting classes in C++ language"

--- a/content/learn/course/intermediate/classes/static-methods.mdx
+++ b/content/learn/course/intermediate/classes/static-methods.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	5
 sidebar_label:		"5. Static methods 🚧"
 title:				"Static methods"
 description:		"Lesson: static methods in C++ language"

--- a/content/learn/course/intermediate/const-correctness.mdx
+++ b/content/learn/course/intermediate/const-correctness.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	11
 sidebar_label:		"11. Const correctness 🚧"
 title:				"Const correctness"
 description:		"Lesson: const correctness in C++ language"

--- a/content/learn/course/intermediate/constants.mdx
+++ b/content/learn/course/intermediate/constants.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	4
 sidebar_label:		"4. Constants (I) 🚧"
 title:				"Constants (I)"
 description:		"Lesson: constants (I) in C++ language"

--- a/content/learn/course/intermediate/exceptions.mdx
+++ b/content/learn/course/intermediate/exceptions.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	9
 sidebar_label:		"9. Exceptions (I) 🚧"
 title:				"Exceptions (I)"
 description:		"Lesson: exceptions in C++ language"

--- a/content/learn/course/intermediate/funcs-and-ops/_category_.json
+++ b/content/learn/course/intermediate/funcs-and-ops/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "6. Functions and operators",
-  "position": 6
-}

--- a/content/learn/course/intermediate/funcs-and-ops/default-arguments.mdx
+++ b/content/learn/course/intermediate/funcs-and-ops/default-arguments.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"1. Default arguments"
 title:				"Default arguments"
 description:		"Lesson: default parameter values in C++ language"

--- a/content/learn/course/intermediate/funcs-and-ops/function-overloading.mdx
+++ b/content/learn/course/intermediate/funcs-and-ops/function-overloading.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		"2. Function overloading 🚧"
 title:				"Function overloading"
 description:		"Lesson: function overloading in C++ language"

--- a/content/learn/course/intermediate/funcs-and-ops/operator-overloading.mdx
+++ b/content/learn/course/intermediate/funcs-and-ops/operator-overloading.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		"3. Operator overloading 🚧"
 title:				"Operator overloading"
 description:		"Lesson: operator overloading in C++ language"

--- a/content/learn/course/intermediate/lambdas.mdx
+++ b/content/learn/course/intermediate/lambdas.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"1. Lambdas (I)"
 title:				"Lambdas (I)"
 description:		"Lesson: Lambdas (I) in C++ language"

--- a/content/learn/course/intermediate/memory/_category_.json
+++ b/content/learn/course/intermediate/memory/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "10. Memory (I)",
-  "position": 10
-}

--- a/content/learn/course/intermediate/memory/arrays.mdx
+++ b/content/learn/course/intermediate/memory/arrays.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		"2. Arrays 🚧"
 title:				"Arrays"
 description:		"Lesson: fixed-size arrays (std::array) in C++ language"

--- a/content/learn/course/intermediate/memory/copying.mdx
+++ b/content/learn/course/intermediate/memory/copying.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		"3. Copying 🚧"
 title:				"Copying"
 description:		"Lesson: value copy mechanism in C++ language"

--- a/content/learn/course/intermediate/memory/move-semantics.mdx
+++ b/content/learn/course/intermediate/memory/move-semantics.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	4
 sidebar_label:		"4. Moving 🚧"
 title:				"Moving"
 description:		"Lesson: value move mechanism in C++ language"

--- a/content/learn/course/intermediate/memory/smart-pointers.mdx
+++ b/content/learn/course/intermediate/memory/smart-pointers.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	5
 sidebar_label:		"5. Smart pointers 🚧"
 title:				"Smart pointers"
 description:		"Lesson: smart pointers in C++ language"

--- a/content/learn/course/intermediate/memory/stack-and-heap.mdx
+++ b/content/learn/course/intermediate/memory/stack-and-heap.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"1. Stack and heap 🚧"
 title:				"Stack and heap"
 description:		"Lesson: the difference between stack and heap allocation in C++ language"

--- a/content/learn/course/intermediate/pointers.mdx
+++ b/content/learn/course/intermediate/pointers.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		"3. Pointers (I) 🚧"
 title:				"Pointers (I)"
 description:		"Lesson: pointers (I) in C++ language"

--- a/content/learn/course/intermediate/preprocessor.mdx
+++ b/content/learn/course/intermediate/preprocessor.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	5
 sidebar_label:		"5. Preprocessor (I) 🚧"
 title:				"Preprocessor (I)"
 description:		"Lesson: preprocessor (I) in C++ language"

--- a/content/learn/course/intermediate/references.mdx
+++ b/content/learn/course/intermediate/references.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		"2. References (II) 🚧"
 title:				"References (II)"
 description:		"Lesson: References (II) in C++ language"

--- a/content/learn/course/intermediate/templates.mdx
+++ b/content/learn/course/intermediate/templates.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	8
 sidebar_label:		"8. Templates (I) 🚧"
 title:				"Templated functions"
 description:		"Lesson: function templates in C++ language"

--- a/content/learn/course/intro.mdx
+++ b/content/learn/course/intro.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"Introduction to C++"
 title:				"Introduction to C++"
 description:		"Introduction to C++ programming language course"

--- a/content/learn/editing-code/_category_.json
+++ b/content/learn/editing-code/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Editing code",
-	"position": 4
-}

--- a/content/learn/editing-code/refactoring.mdx
+++ b/content/learn/editing-code/refactoring.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 2
 completion: false
 ---
 

--- a/content/learn/editing-code/using-debugger.mdx
+++ b/content/learn/editing-code/using-debugger.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 completion: false
 ---
 

--- a/content/learn/golden-advices/_category_.json
+++ b/content/learn/golden-advices/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Golden advices 💰",
-	"position": 6
-}

--- a/content/learn/golden-advices/index.mdx
+++ b/content/learn/golden-advices/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 slug: /golden-advices/
 sidebar_label: Intro
 ---

--- a/content/learn/golden-advices/memory.mdx
+++ b/content/learn/golden-advices/memory.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 completion: false
 ---
 

--- a/content/learn/index.mdx
+++ b/content/learn/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 slug: /
 ---
 

--- a/content/tools/compilers.mdx
+++ b/content/tools/compilers.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		🎯 Choose a compiler
 title: 				Choose a compiler
 description:		Select a preferred C++ compiler using our tutorials.

--- a/content/tools/editors.mdx
+++ b/content/tools/editors.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		🎯 Choose an editor
 title:				Choose an editor
 tags:				[editor, visual-studio, vs-code, qtcreator, repl-it, tool, windows, linux]

--- a/content/tools/index.mdx
+++ b/content/tools/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		🛠 Development tools
 title:				Development tools
 hide_title:			true

--- a/content/tools/online/_category_.json
+++ b/content/tools/online/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Online tools",
-	"position": 4
-}

--- a/content/tools/online/comparison.mdx
+++ b/content/tools/online/comparison.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 0
 title: 📊 Comparison
 completion: false
 ---

--- a/content/tools/online/godbolt.mdx
+++ b/content/tools/online/godbolt.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 3
 completion: false
 ---
 

--- a/content/tools/online/ideone.mdx
+++ b/content/tools/online/ideone.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	4
 sidebar_label:		Using ideone.com
 title:				Using ideone.com
 tags:				[editor, compiler, gcc, clang, tool, ide, ideone]

--- a/content/tools/online/replit.mdx
+++ b/content/tools/online/replit.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		Using Replit.com
 title:				Using Replit.com
 tags:				[editor, compiler, gcc, clang, tool, ide]

--- a/content/tools/online/wandbox.mdx
+++ b/content/tools/online/wandbox.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 2
 completion: false
 ---
 

--- a/content/tools/standalone/_category_.json
+++ b/content/tools/standalone/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Standalone tools",
-	"position": 5
-}

--- a/content/tools/standalone/compilers/_category_.json
+++ b/content/tools/standalone/compilers/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Compilers",
-	"position": 2
-}

--- a/content/tools/standalone/compilers/setup-clang-linux.mdx
+++ b/content/tools/standalone/compilers/setup-clang-linux.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	4
 title:				Setup Clang on Linux
 description:		Learn how to setup Clang C++ Compiler on Linux easily.
 tags:				[compiler, tool, clang, linux]

--- a/content/tools/standalone/compilers/setup-clang-macos.mdx
+++ b/content/tools/standalone/compilers/setup-clang-macos.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	6
 title:				Setup Clang on MacOS
 description:		Learn how to setup Clang C++ Compiler on MacOS easily.
 tags:				[compiler, tool, clang, mac]

--- a/content/tools/standalone/compilers/setup-clang-windows.mdx
+++ b/content/tools/standalone/compilers/setup-clang-windows.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	4
 title:				Setup Clang on Windows
 description:		Learn how to setup Clang C++ Compiler on Windows easily.
 tags:				[compiler, tool, clang, windows]

--- a/content/tools/standalone/compilers/setup-gcc-linux.mdx
+++ b/content/tools/standalone/compilers/setup-gcc-linux.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 title:				Setup GCC on Linux
 description:		Learn how to setup GNU C++ Compiler on Linux easily.
 tags:				[compiler, tool, gcc, linux]

--- a/content/tools/standalone/compilers/setup-gcc-macos.mdx
+++ b/content/tools/standalone/compilers/setup-gcc-macos.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 title:				Setup GCC on MacOS
 description:		Learn how to setup GNU C++ Compiler on MacOS easily.
 tags:				[compiler, tool, gcc, mac]

--- a/content/tools/standalone/compilers/setup-gcc-windows.mdx
+++ b/content/tools/standalone/compilers/setup-gcc-windows.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 title:				Setup GCC on Windows
 description:		Learn how to setup GNU C++ Compiler on Windows easily.
 tags:				[compiler, tool, gcc, windows]

--- a/content/tools/standalone/editors/_category_.json
+++ b/content/tools/standalone/editors/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Editors",
-	"position": 1
-}

--- a/content/tools/standalone/editors/setup-clion.mdx
+++ b/content/tools/standalone/editors/setup-clion.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 3
 completion: false
 ---
 

--- a/content/tools/standalone/editors/setup-emacs.mdx
+++ b/content/tools/standalone/editors/setup-emacs.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 5
 title: Emacs setup
 description:		Learn how to setup Emacs for coding in C++ Compiler easily.
 tags:				[editor, tool, emacs, lsp-mode, linux]

--- a/content/tools/standalone/editors/setup-qtcreator.mdx
+++ b/content/tools/standalone/editors/setup-qtcreator.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 4
 completion: false
 ---
 

--- a/content/tools/standalone/editors/setup-vscode.mdx
+++ b/content/tools/standalone/editors/setup-vscode.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 completion: false
 ---
 

--- a/content/tools/standalone/editors/vs2022/_category_.json
+++ b/content/tools/standalone/editors/vs2022/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Visual Studio 2022",
-	"position": 2
-}

--- a/content/tools/standalone/editors/vs2022/creating-projects.mdx
+++ b/content/tools/standalone/editors/vs2022/creating-projects.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 title:				Creating projects in Visual Studio 2022
 sidebar_label:		Creating projects
 description:		Learn how to create projects in Visual Studio 2022

--- a/content/tools/standalone/editors/vs2022/managing-projects.mdx
+++ b/content/tools/standalone/editors/vs2022/managing-projects.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	4
 title:				Managing projects in Visual Studio 2022
 sidebar_label:		Managing projects
 description:		Learn how to manage projects and edit their settings in Visual Studio 2022

--- a/content/tools/standalone/editors/vs2022/setup.mdx
+++ b/content/tools/standalone/editors/vs2022/setup.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 title:				Setting up Visual Studio 2022
 sidebar_label:		Installation
 description:		Learn how to setup Visual Studio 2022 easily

--- a/content/tools/standalone/editors/vs2022/using-debugger.mdx
+++ b/content/tools/standalone/editors/vs2022/using-debugger.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 title:				Using debugger in Visual Studio 2022
 sidebar_label:		Using debugger
 description:		Learn how to use debugger in Visual Studio 2022

--- a/i18n/pl/docusaurus-plugin-content-docs-community/current/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-community/current/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		👥 Społeczność
 title:				Społeczność
 hide_title:			true

--- a/i18n/pl/docusaurus-plugin-content-docs-features/current/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-features/current/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 slug: /
 completion: false
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Compilation",
-	"position": 5
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/compilation-process.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/compilation-process.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 2
 completion: false
 ---
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/linker.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/linker.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 4
 completion: false
 ---
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/multiple-files.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/multiple-files.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 5
 completion: false
 ---
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/preprocessor.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/preprocessor.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 3
 completion: false
 ---
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/target-types.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/target-types.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 6
 completion: false
 ---
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/what-is-compiler.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/compilation/what-is-compiler.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 completion: false
 ---
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/_category_.json
@@ -1,5 +1,0 @@
-{
-	"label": "Kurs C++",
-	"position": 3,
-	"collapsed": false
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/advanced/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/advanced/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "Advanced",
-  "position": 4
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "Basics",
-  "position": 2
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/aliases.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/aliases.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	13
 sidebar_label:		"13. Aliasy 🚧"
 title:				Aliasy
 description:		"Lekcja: podstawy aliasów w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/arrays/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/arrays/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "Arrays",
-  "position": 5
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/arrays/exercises.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/arrays/exercises.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		"3. Ćwiczenia 🚧"
 title:				Ćwiczenia
 description: 		"Lekcja: ćwiczenia z użyciem vectora w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/arrays/intro-to-vector.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/arrays/intro-to-vector.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"1. Wstęp do vector-ów"
 title:				Wstęp do vector-ów
 description: 		"Lekcja: wstęp do tablic z użyciem vectora w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/articles/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/articles/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Articles",
-	"position": 15
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/articles/console.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/articles/console.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		🖥 Konsola
 title:				Konsola
 tags:				[konsola, zależne-od-systemu]

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/articles/random.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/articles/random.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		🎲 Losowość
 title:				Liczby pseudolosowe
 tags:				[losowość, liczby-pseudolosowe]

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/comments.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/comments.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 	2
 sidebar_label:		"2. Komentarze"
 title:				Komentarze
 description: 		"Lekcja: komentarze w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/conditions.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/conditions.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	4
 sidebar_label:		"4. Instrukcje warunkowe"
 title:				"Instrukcje warunkowe"
 description:		"Lekcja: instrukcje warunkowe w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/conditions/_category.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/conditions/_category.json
@@ -1,4 +1,0 @@
-{
-  "label": "4. Conditions",
-  "position": 4
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/conditions/compound.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/conditions/compound.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	4
 sidebar_label:		"2. Złożone Warunki"
 title:				"Złożone Warunki"
 description:		"Lekcja: złożone warunki w C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/conditions/intro.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/conditions/intro.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	4
 sidebar_label:		"1. Wprowadzenie"
 title:				"Wprowadzenie do warunków"
 description:		"Lekcja: podstawy warunków w C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/enums.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/enums.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	13
 sidebar_label:		"13. Enumeracje 🚧"
 title:				Enumeracje
 description:		"Lekcja: podstawy enumeracji w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/example-programs/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/example-programs/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "💻 Examples",
-  "position": 16
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/example-programs/advanced-calc.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/example-programs/advanced-calc.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		➗ Zaawansowany kalkulator
 title:				Zaawansowany kalkulator
 description:		"Przykładowy program: zaawansowany kalkulator w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/example-programs/combat-arena.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/example-programs/combat-arena.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		👾 Arena walki
 title:				Arena walki
 description:		"Przykładowy program: arena walki (gra konsolowa) w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/example-programs/simple-calc.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/example-programs/simple-calc.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		➕ Podstawowy kalkulator
 title:				Podstawowy kalkulator
 description:		"Przykładowy program: zaawansowany kalkulator w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/first-program.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/first-program.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"1. Pierwszy program"
 title:				"Pierwszy program"
 description:		"Lekcja: pierwszy program w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/functions/functions.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/functions/functions.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	7
 sidebar_label:		"7. Funkcje"
 title:				"Funkcje"
 description:		"Lekcja: funkcje w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/inheritance.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/inheritance.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	10
 sidebar_label:		"10. Dziedziczenie"
 title:				Dziedziczenie
 description:		"Lekcja: podstawy dziedziczenia w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/loops.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/loops.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	6
 sidebar_label:		"6. Pętle"
 title:				"Pętle"
 description:		"Lekcja: pętle w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/methods.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/methods.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	9
 sidebar_label:		"9. Metody"
 title:				"Metody"
 description:		"Lekcja: podstawy metod w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/namespaces.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/namespaces.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	14
 sidebar_label:		"14. Przestrzenie nazw 🚧"
 title:				Przestrzenie nazw
 description:		"Lekcja: podstawy przestrzeni nazw w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/polymorphism.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/polymorphism.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	12
 sidebar_label:		"12. Polimorfizm 🚧"
 title:				Polimorfizm
 description:		"Lekcja: podstawy polimorfizmu w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/references.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/references.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	11
 sidebar_label:		"11. Referencje 🚧"
 title:				Referencje
 description:		"Lekcja: podstawy referencji w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/variables/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/variables/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "3. Variables",
-  "position": 3
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/variables/intro.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/variables/intro.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"1. Wprowadzenie"
 title:				"Wprowadzenie"
 description:		"Lekcja: wprowadzenie do zmiennych w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/variables/operations.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/variables/operations.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		"2. Operacje"
 title:				"Operacje"
 description:		"Lekcja: podstawowe operacje na zmiennych w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/variables/strings.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/basics/variables/strings.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		"3. Napisy"
 title:				"Napisy"
 description:		"Lekcja: podstawy napisów w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "🟡 Intermediate",
-  "position": 3
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "9. Classes (I)",
-  "position": 9
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/class-namespaces.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/class-namespaces.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	7
 sidebar_label:		"7. Przestrzeń nazw klasy 🚧"
 title:				"Przestrzeń nazw klasy"
 description:		"Lekcja: Przestrzeń nazw klasy w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/const-methods.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/const-methods.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	4
 sidebar_label:		"4. Metody stałych 🚧"
 title:				"Metody stałych"
 description:		"Lekcja: metody stałych obiektów w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/constructors.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/constructors.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		"2. Konstruktory (I) 🚧"
 title:				"Konstruktory (I)"
 description:		"Lekcja: konstruktory klas (I) w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/destructors.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/destructors.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		"3. Destruktory 🚧"
 title:				"Destruktory"
 description:		"Lekcja: destruktory klas w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/intro.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/intro.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"1. Wstęp 🚧"
 title:				"Wstęp do klas"
 description:		"Lekcja: wstęp do klas w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/nested-classes.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/nested-classes.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	6
 sidebar_label:		"6. Klasy zagnieżdżone 🚧"
 title:				"Klasy zagnieżdżone"
 description:		"Lekcja: zagnieżdżanie klas w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/static-methods.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/classes/static-methods.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	5
 sidebar_label:		"5. Metody statyczne 🚧"
 title:				"Metody statyczne"
 description:		"Lekcja: statyczne metody klas w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/const-correctness.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/const-correctness.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	11
 sidebar_label:		"11. Poprawność stałych 🚧"
 title:				"Poprawność stałych"
 description:		"Lekcja: poprawność używania stałych w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/constants.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/constants.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	4
 sidebar_label:		"4. Stałe (I) 🚧"
 title:				"Stałe (I)"
 description:		"Lekcja: stałe (I) w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/exceptions.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/exceptions.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	8
 sidebar_label:		"8. Wyjątki (I) 🚧"
 title:				"Wyjątki (I)"
 description:		"Lekcja: wyjątki w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/funcs-and-ops/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/funcs-and-ops/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "6. Functions and operators",
-  "position": 6
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/funcs-and-ops/default-arguments.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/funcs-and-ops/default-arguments.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"1. Domyślne argumenty"
 title:				Domyślne argumenty
 description:		"Lekcja: domyślne wartości parametrów w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/funcs-and-ops/function-overloading.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/funcs-and-ops/function-overloading.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		"2. Przeładowanie funkcji 🚧"
 title:				"Przeładowanie funkcji"
 description:		"Lekcja: przeładowanie funkcji w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/funcs-and-ops/operator-overloading.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/funcs-and-ops/operator-overloading.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		"3. Przeładowanie operatorów 🚧"
 title:				"Przeładowanie operatorów"
 description:		"Lekcja: przeładowanie operatorów w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/lambdas.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/lambdas.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"1. Lambdy (I)"
 title:				"Lambdy (I)"
 description:		"Lekcja: lambdy (I) w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "10. Memory (I)",
-  "position": 10
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/arrays.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/arrays.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		"2. Tablice 🚧"
 title:				"Tablice"
 description:		"Lekcja: tablice (std::array) języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/copying.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/copying.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		"3. Kopiowanie 🚧"
 title:				"Kopiowanie"
 description:		"Lekcja: działanie kopiowania wartości języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/move-semantics.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/move-semantics.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	4
 sidebar_label:		"4. Przenoszenie 🚧"
 title:				"Przenoszenie"
 description:		"Lekcja: semantyka przeniesienia (std::move) w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/smart-pointers.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/smart-pointers.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	5
 sidebar_label:		"5. Inteligentne wskaźniki 🚧"
 title:				"Inteligentne wskaźniki"
 description:		"Lekcja: inteligentne wskaźniki w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/stack-and-heap.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/memory/stack-and-heap.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"1. Stos i sterta 🚧"
 title:				"Stos i sterta"
 description:		"Lekcja: różnica między alokacją na stosie a na stercie w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/pointers.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/pointers.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		"3. Wskaźniki (I) 🚧"
 title:				"Wskaźniki (I)"
 description:		"Lekcja: wskaźniki (I) w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/preprocessor.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/preprocessor.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	5
 sidebar_label:		"5. Preprocesor (I) 🚧"
 title:				"Preprocesor (I)"
 description:		"Lekcja: preprocesor (I) w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/references.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/references.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		"2. Referencje (II) 🚧"
 title:				"Referencje (II)"
 description:		"Lekcja: referencje (II) w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/templates.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intermediate/templates.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	7
 sidebar_label:		"7. Szablony (I) 🚧"
 title:				"Szablony funkcji"
 description:		"Lekcja: szablony funkcji w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intro.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/course/intro.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		"Wstęp do C++"
 title:				"Wstęp do C++"
 description:		"Wprowadzanie do kursu programowania w języku C++"

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/editing-code/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/editing-code/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Editing code",
-	"position": 4
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/editing-code/refactoring.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/editing-code/refactoring.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 2
 completion: false
 ---
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/editing-code/using-debugger.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/editing-code/using-debugger.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 completion: false
 ---
 

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/golden-advices/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/golden-advices/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Golden advices 💰",
-	"position": 6
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/golden-advices/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/golden-advices/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		Wstęp
 title:				Złote rady
 hide_title:			true

--- a/i18n/pl/docusaurus-plugin-content-docs-learn/current/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-learn/current/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 slug: /
 ---
 

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/compilers.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/compilers.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 sidebar_label:		🎯 Wybór kompilatora
 title:				Wybór kompilatora
 description:		Wybierz odpowiedni kompilator C++ korzystając z naszych poradników.

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/editors.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/editors.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 sidebar_label:		🎯 Wybór edytora
 title:				Wybór edytora
 tags:				[edytor, visual-studio, vs-code, qtcreator, repl-it, narzędzie, windows, linux]

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		🛠 Narzędzia programistyczne
 title:				Narzędzia programistyczne
 tags:				[edytor, kompilator, narzędzie, gcc, clang, visual-studio, vs-code, qtcreator, repl-it]

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Online tools",
-	"position": 4
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/comparison.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/comparison.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 0
 title: 📊 Porównanie
 completion: false
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/godbolt.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/godbolt.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 3
 completion: false
 ---
 

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/ideone.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/ideone.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 	4
 sidebar_label:		Korzystanie z ideone.com
 title:				Korzystanie z ideone.com
 tags:				[editor, compiler, gcc, clang, tool, ide, ideone]

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/replit.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/replit.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 sidebar_label:		Korzystanie z Replit.com
 title:				Korzystanie z Replit.com
 tags:				[edytor, kompilator, gcc, clang, narzędzie]

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/wandbox.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/online/wandbox.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 2
 completion: false
 ---
 

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Standalone tools",
-	"position": 5
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Compilers",
-	"position": 2
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-clang-linux.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-clang-linux.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	5
 title:				Instalacja Clang (Linux)
 description:		Naucz się jak skonfigurować Clang (kompilator C++) na Linuksie w prosty sposób.
 tags:				[kompilator, narzędzie, clang, linux]

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-clang-macos.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-clang-macos.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	6
 title:				Instalacja Clang (MacOS)
 description:		Naucz się jak skonfigurować Clang (kompilator C++) na MacOS w prosty sposób.
 tags:				[compiler, tool, clang, mac]

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-clang-windows.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-clang-windows.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	4
 title:				Instalacja Clang (Windows)
 description:		Naucz się jak skonfigurować Clang (kompilator C++) na Windowsie w prosty sposób.
 tags:				[kompilator, narzędzie, clang, windows]

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-gcc-linux.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-gcc-linux.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 title:				Instalacja GCC (Linux)
 description:		Naucz się jak skonfigurować GCC (kompilator C++) na Linuksie w prosty sposób.
 tags:				[kompilator, narzędzie, gcc, linux]

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-gcc-macos.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-gcc-macos.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 title:				Instalacja GCC (MacOS)
 description:		Naucz się jak skonfigurować GCC (kompilator C++) na MacOS w prosty sposób.
 tags:				[compiler, tool, gcc, mac]

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-gcc-windows.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/compilers/setup-gcc-windows.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 title:				Instalacja GCC (Windows)
 description:		Naucz się jak skonfigurować GCC (kompilator C++) na Windowsie w prosty sposób.
 tags:				[kompilator, narzędzie, gcc, windows]

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Editors",
-	"position": 1
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/setup-clion.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/setup-clion.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 3
 completion: false
 ---
 

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/setup-qtcreator.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/setup-qtcreator.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 4
 completion: false
 ---
 

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/setup-vs2022.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/setup-vs2022.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 title:				Instalacja Visual Studio 2022
 description:		Naucz się jak zainstalować Visual Studio 2022 w prosty sposób.
 tags:				[visual-studio, edytor, kompilator, narzędzie, windows]

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/setup-vscode.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/setup-vscode.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 completion: false
 ---
 

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Visual Studio 2022",
-	"position": 2
-}

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/creating-projects.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/creating-projects.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	2
 title:				Tworzenie projektów w Visual Studio 2022
 sidebar_label:		Tworzenie projektów
 description:		Learn how to create projects in Visual Studio 2022

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/managing-projects.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/managing-projects.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	4
 title:				Zarządzanie projektami w Visual Studio 2022
 sidebar_label:		Zarządzanie projektami
 description:		Naucz się jak zarządzać projektami w Visual Studio 2022

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/setup.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/setup.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 title:				Instalacja Visual Studio 2022
 sidebar_label:		Instalacja
 description:		Naucz się jak zainstalować Visual Studio 2022 w prosty sposób.

--- a/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/using-debugger.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs-tools/current/standalone/editors/vs2022/using-debugger.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	3
 title:				Debugowanie w Visual Studio 2022
 sidebar_label:		Debugowanie
 description:		Naucz się jak korzystać z debuggera w Visual Studio 2022

--- a/i18n/pl/docusaurus-plugin-content-docs/current/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 slug: /
 completion: false
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/_category_.json
@@ -1,5 +1,0 @@
-{
-	"label": "Standard library",
-	"position": 2,
-	"collapsed": "false"
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/algo/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/algo/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Algorithms",
-	"position": 5
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/algo/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/algo/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/algo/
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/concepts/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/concepts/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Concepts",
-	"position": 8
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/concepts/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/concepts/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/concepts/
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Containers",
-	"position": 4
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/arrays/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/arrays/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Arrays",
-	"position": 2
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/arrays/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/arrays/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/containers/arrays/
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/containers/
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/maps/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/maps/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Maps and dictionaries",
-	"position": 5
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/maps/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/maps/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/containers/maps/
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/other/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/other/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Other",
-	"position": 7
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/other/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/other/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/containers/other/
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/queues/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/queues/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Queues",
-	"position": 4
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/queues/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/queues/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/containers/queues/
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/sets/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/sets/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Sets",
-	"position": 6
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/sets/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/sets/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/containers/sets/
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/strings/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/strings/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Strings",
-	"position": 3
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/strings/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/containers/strings/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/containers/strings/
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/date-time/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/date-time/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Date and time",
-	"position": 11
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/date-time/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/date-time/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/containers/date-time/
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position:	1
 title:				Biblioteka standardowa
 hide_title:			true
 slug: /std/

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/io/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/io/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Input and output",
-	"position": 3
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/io/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/io/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/io/
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/iterators/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/iterators/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Iterators",
-	"position": 6
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/iterators/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/iterators/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/iterators/
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/lang-support/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/lang-support/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Language support",
-	"position": 9
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/lang-support/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/lang-support/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/lang-support/
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/math/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/math/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Math",
-	"position": 2
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/math/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/math/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/math/
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/memory/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/memory/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Memory management",
-	"position": 10
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/memory/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/memory/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/memory/
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/ranges/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/ranges/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Ranges",
-	"position": 7
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/ranges/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/ranges/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/ranges/
 ---

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/utility/_category_.json
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/utility/_category_.json
@@ -1,4 +1,0 @@
-{
-	"label": "Utility",
-	"position": 12
-}

--- a/i18n/pl/docusaurus-plugin-content-docs/current/std/utility/index.mdx
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/std/utility/index.mdx
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: Summary
 slug: /std/utility/
 ---


### PR DESCRIPTION
<!--
  Thank you for contributing!
  Provide a description of your changes below and a general summary in the title.
-->

## Description

<!--- Describe your changes in detail here -->

## Type of Change

<!--- Put an `x` ( and remove spaces ) in all the boxes that apply: -->

### Changes in platform

- 🗑️ chore - remove legacy sidebar info (`_category_` files, `sidebar_position` frontmatter data)